### PR TITLE
chore: simplify CODEOWNERS, remove stale monorepo paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,2 @@
 # Default owner for everything
 * @kopahead
-
-# Server
-apps/server/ @kopahead
-
-# Packages
-packages/ @kopahead


### PR DESCRIPTION
## Summary
- Remove `apps/server/` and `packages/` paths from CODEOWNERS (stale monorepo paths)
- The wildcard `* @kopahead` already covers the entire repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)