### PR TITLE
fix: set cookie domain for cross-subdomain auth

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,18 @@ export const JWT_SECRET = (() => {
 })()
 export const CORS_ORIGINS = requireEnv('CORS_ORIGINS').split(',')
 export const DASHBOARD_URL = process.env.DASHBOARD_URL || ''
+
+// Cookie domain — derived from DASHBOARD_URL so cookies work across subdomains
+// e.g. https://supaproxy.cloud → .supaproxy.cloud
+export const COOKIE_DOMAIN = (() => {
+  if (!DASHBOARD_URL) return undefined
+  try {
+    const host = new URL(DASHBOARD_URL).hostname
+    return host.startsWith('.') ? host : `.${host}`
+  } catch {
+    return undefined
+  }
+})()
 export const PORT = requireEnvInt('PORT')
 
 // Database

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -6,7 +6,7 @@ import { z } from 'zod'
 import pino from 'pino'
 import { getPool } from '../db/pool.js'
 import { findUserByEmail, verifyPassword, hashPassword } from '../auth/db.js'
-import { JWT_SECRET, DASHBOARD_URL, IS_PRODUCTION, DEFAULT_MODEL } from '../config.js'
+import { JWT_SECRET, DASHBOARD_URL, IS_PRODUCTION, DEFAULT_MODEL, COOKIE_DOMAIN } from '../config.js'
 import { parseBody } from '../middleware/validate.js'
 import type { IdRow } from '../db/types.js'
 
@@ -78,6 +78,7 @@ auth.post('/api/signup', async (c) => {
     sameSite: 'Lax',
     path: '/',
     maxAge: SESSION_MAX_AGE,
+    ...(COOKIE_DOMAIN && { domain: COOKIE_DOMAIN }),
   })
 
   log.info({ org: org_name, admin: admin_email, workspace: wsId }, 'Setup complete — org, admin, team, workspace created')
@@ -137,6 +138,7 @@ auth.post('/api/auth/login', async (c) => {
     sameSite: 'Lax',
     path: '/',
     maxAge: SESSION_MAX_AGE,
+    ...(COOKIE_DOMAIN && { domain: COOKIE_DOMAIN }),
   })
 
   if (isFormSubmit && DASHBOARD_URL) return c.redirect(`${DASHBOARD_URL}/workspaces`)
@@ -169,7 +171,7 @@ auth.get('/api/auth/session', (c) => {
 
 // --- Logout ---
 auth.get('/api/auth/logout', (c) => {
-  setCookie(c, 'supaproxy_session', '', { path: '/', maxAge: 0 })
+  setCookie(c, 'supaproxy_session', '', { path: '/', maxAge: 0, ...(COOKIE_DOMAIN && { domain: COOKIE_DOMAIN }) })
   if (DASHBOARD_URL) return c.redirect(`${DASHBOARD_URL}/login`)
   return c.json({ status: 'ok' })
 })


### PR DESCRIPTION
## Summary
- Derive `COOKIE_DOMAIN` from `DASHBOARD_URL` (e.g. `https://supaproxy.cloud` → `.supaproxy.cloud`)
- Set `domain` on all session cookies (signup, login, logout)
- Without this, cookies set on `api.supaproxy.cloud` are not sent to `supaproxy.cloud`, so the dashboard never sees the session

## Test plan
- [ ] Login from supaproxy.cloud redirects to /workspaces with valid session
- [ ] Session check on dashboard pages works (cookie sent cross-subdomain)
- [ ] Logout clears the cookie on both domains

🤖 Generated with [Claude Code](https://claude.com/claude-code)