### PR TITLE
feat: API key management — migration, routes, and requireApiKey middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+- API key management: `POST/GET/DELETE /api/workspaces/:id/api-keys` routes for creating, listing, and revoking workspace API keys
+- `requireApiKey` middleware and `ApiKeyEnv` type — bearer token auth path for the MCP server
+- `api_keys` table (migration 6): hashed key storage, display prefix, label, audit timestamps
+- OpenAPI documentation for all three API key routes under the new `API Keys` tag
+
 ## [0.1.0] - 2026-04-25
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ src/
 ├── index.ts           Hono app, health check, route mounts
 ├── shared/            Types, entities, API contracts
 ├── middleware/
-│   ├── auth.ts        requireAuth (JWT cookie verification)
+│   ├── auth.ts        requireAuth (JWT cookie), requireApiKey (bearer token for MCP)
 │   └── validate.ts    parseBody (Zod schema validation)
 ├── routes/            Modular Hono routers
 │   ├── auth.ts        Login, logout, session, signup
@@ -19,6 +19,7 @@ src/
 │   ├── workspaces.ts  Workspace CRUD, dashboard, activity
 │   ├── conversations.ts Conversation list, detail, close
 │   ├── connectors.ts  MCP + Slack connectors
+│   ├── api-keys.ts    Workspace API key management (create, list, revoke)
 │   └── query.ts       Agent loop entry point
 ├── core/              Business logic
 │   ├── agent.ts       AI + MCP tool orchestration

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -325,6 +325,27 @@ const migrations: Migration[] = [
       }
     },
   },
+  {
+    version: 6,
+    name: 'add api_keys table',
+    up: async (pool) => {
+      await pool.execute(`
+        CREATE TABLE IF NOT EXISTS api_keys (
+          id VARCHAR(64) PRIMARY KEY,
+          workspace_id VARCHAR(64) NOT NULL,
+          key_hash VARCHAR(64) NOT NULL,
+          key_prefix VARCHAR(20) NOT NULL,
+          label VARCHAR(255) NOT NULL,
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+          last_used_at TIMESTAMP NULL,
+          revoked_at TIMESTAMP NULL,
+          UNIQUE KEY unique_key_hash (key_hash),
+          INDEX idx_workspace (workspace_id),
+          FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+        )
+      `);
+    },
+  },
 ];
 
 interface SchemaMigrationRow extends mysql.RowDataPacket {

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -179,6 +179,17 @@ export interface ModelRow extends RowDataPacket {
   is_default: boolean
 }
 
+export interface ApiKeyRow extends RowDataPacket {
+  id: string
+  workspace_id: string
+  key_hash: string
+  key_prefix: string
+  label: string
+  created_at: string
+  last_used_at: string | null
+  revoked_at: string | null
+}
+
 export interface ColumnInfoRow extends RowDataPacket {
   Field: string
   Type: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import queuesRouter from './routes/queues.js'
 import workspacesRouter from './routes/workspaces.js'
 import conversationsRouter from './routes/conversations.js'
 import connectorsRouter from './routes/connectors.js'
+import apiKeysRouter from './routes/api-keys.js'
 import queryRouter from './routes/query.js'
 import docs from './openapi.js'
 
@@ -83,6 +84,7 @@ app.route('/', queuesRouter)
 app.route('/', workspacesRouter)
 app.route('/', conversationsRouter)
 app.route('/', connectorsRouter)
+app.route('/', apiKeysRouter)
 app.route('/', queryRouter)
 
 // API docs (mounted last — spec-only routes for /docs, /api/openapi.json, /public/*)

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,10 +1,13 @@
 import { getCookie } from 'hono/cookie'
 import { createHash } from 'crypto'
 import jwt from 'jsonwebtoken'
+import pino from 'pino'
 import { JWT_SECRET } from '../config.js'
 import { getPool } from '../db/pool.js'
 import type { ApiKeyRow } from '../db/types.js'
 import type { Context, Next } from 'hono'
+
+const log = pino({ name: 'middleware/auth' })
 
 export interface AuthUser {
   id: string
@@ -66,7 +69,9 @@ export async function requireApiKey(c: Context, next: Next) {
   c.set('is_test_key', key.startsWith('sp_test_'))
 
   // Update last_used_at without blocking the request
-  db.execute('UPDATE api_keys SET last_used_at = NOW() WHERE id = ?', [apiKey.id]).catch(() => {})
+  db.execute('UPDATE api_keys SET last_used_at = NOW() WHERE id = ?', [apiKey.id]).catch((err: unknown) => {
+    log.warn({ error: (err as Error).message, keyId: apiKey.id }, 'Failed to update api key last_used_at')
+  })
 
   await next()
 }

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,6 +1,9 @@
 import { getCookie } from 'hono/cookie'
+import { createHash } from 'crypto'
 import jwt from 'jsonwebtoken'
 import { JWT_SECRET } from '../config.js'
+import { getPool } from '../db/pool.js'
+import type { ApiKeyRow } from '../db/types.js'
 import type { Context, Next } from 'hono'
 
 export interface AuthUser {
@@ -29,6 +32,43 @@ export async function requireAuth(c: Context, next: Next) {
   } catch {
     return c.json({ error: 'Invalid session' }, 401)
   }
+}
+
+export type ApiKeyEnv = {
+  Variables: {
+    workspace_id: string
+    is_test_key: boolean
+  }
+}
+
+/** Require a valid API key. Returns 401 if missing, invalid, or revoked. Sets workspace_id and is_test_key on context. */
+export async function requireApiKey(c: Context, next: Next) {
+  const authHeader = c.req.header('Authorization')
+  if (!authHeader?.startsWith('Bearer ')) return c.json({ error: 'API key required' }, 401)
+
+  const key = authHeader.slice(7)
+  if (!key.startsWith('sp_live_') && !key.startsWith('sp_test_')) {
+    return c.json({ error: 'Invalid API key format' }, 401)
+  }
+
+  const keyHash = createHash('sha256').update(key).digest('hex')
+  const db = getPool()
+  const [rows] = await db.execute<ApiKeyRow[]>(
+    'SELECT id, workspace_id, revoked_at FROM api_keys WHERE key_hash = ?',
+    [keyHash]
+  )
+
+  const apiKey = rows[0]
+  if (!apiKey) return c.json({ error: 'Invalid API key' }, 401)
+  if (apiKey.revoked_at) return c.json({ error: 'API key has been revoked' }, 401)
+
+  c.set('workspace_id', apiKey.workspace_id)
+  c.set('is_test_key', key.startsWith('sp_test_'))
+
+  // Update last_used_at without blocking the request
+  db.execute('UPDATE api_keys SET last_used_at = NOW() WHERE id = ?', [apiKey.id]).catch(() => {})
+
+  await next()
 }
 
 /** Parse JWT if present but don't require it. Sets c.get('user') or null. */

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -218,6 +218,31 @@ const SlackConnectorBody = z.object({
   channel_id: z.string().max(100).optional(),
 }).openapi('SlackConnectorBody')
 
+const ApiKey = z.object({
+  id: z.string(),
+  prefix: z.string().openapi({ description: 'First 16 characters of the key, for identification only' }),
+  label: z.string(),
+  created_at: z.string(),
+  last_used_at: z.string().nullable(),
+}).openapi('ApiKey')
+
+const ApiKeyListResponse = z.object({
+  keys: z.array(ApiKey),
+}).openapi('ApiKeyListResponse')
+
+const CreateApiKeyBody = z.object({
+  label: z.string().min(1).max(255),
+  test: z.boolean().optional().openapi({ description: 'If true, generates a sp_test_ key. Test keys bypass rate limits and billing.' }),
+}).openapi('CreateApiKeyBody')
+
+const CreateApiKeyResponse = z.object({
+  id: z.string(),
+  key: z.string().openapi({ description: 'The full API key — shown once only, never retrievable again' }),
+  prefix: z.string(),
+  label: z.string(),
+  created_at: z.string(),
+}).openapi('CreateApiKeyResponse')
+
 // ── OpenAPI spec app ──────────────────────────────────────────────
 
 const docs = new OpenAPIHono()
@@ -541,6 +566,58 @@ docs.openapi(createRoute({
   responses: { 200: { description: 'Connected', content: { 'application/json': { schema: z.object({ status: z.string(), message: z.string() }) } } } },
 }), (c) => c.json({} as never))
 
+// --- API Keys ---
+
+docs.openapi(createRoute({
+  method: 'post', path: '/api/workspaces/{id}/api-keys', tags: tag('API Keys'),
+  summary: 'Create an API key for a workspace',
+  description: 'Creates a new API key scoped to the workspace. The full key is returned exactly once — it is hashed before storage and cannot be retrieved again.',
+  security: [{ cookieAuth: [] }],
+  request: {
+    params: z.object({ id: z.string().openapi({ param: { name: 'id', in: 'path' } }) }),
+    body: { content: { 'application/json': { schema: CreateApiKeyBody } } },
+  },
+  responses: {
+    201: { description: 'Key created. Store it now — it will not be shown again.', content: { 'application/json': { schema: CreateApiKeyResponse } } },
+    400: { description: 'Validation error', content: { 'application/json': { schema: ErrorResponse } } },
+    401: { description: 'Not authenticated', content: { 'application/json': { schema: ErrorResponse } } },
+    404: { description: 'Workspace not found', content: { 'application/json': { schema: ErrorResponse } } },
+  },
+}), (c) => c.json({} as never))
+
+docs.openapi(createRoute({
+  method: 'get', path: '/api/workspaces/{id}/api-keys', tags: tag('API Keys'),
+  summary: 'List API keys for a workspace',
+  description: 'Returns active (non-revoked) keys with prefix and metadata. The raw key value is never returned.',
+  security: [{ cookieAuth: [] }],
+  request: {
+    params: z.object({ id: z.string().openapi({ param: { name: 'id', in: 'path' } }) }),
+  },
+  responses: {
+    200: { description: 'Active keys', content: { 'application/json': { schema: ApiKeyListResponse } } },
+    401: { description: 'Not authenticated', content: { 'application/json': { schema: ErrorResponse } } },
+    404: { description: 'Workspace not found', content: { 'application/json': { schema: ErrorResponse } } },
+  },
+}), (c) => c.json({} as never))
+
+docs.openapi(createRoute({
+  method: 'delete', path: '/api/workspaces/{id}/api-keys/{keyId}', tags: tag('API Keys'),
+  summary: 'Revoke an API key',
+  description: 'Immediately revokes the key. Any requests using it will receive 401 after this point.',
+  security: [{ cookieAuth: [] }],
+  request: {
+    params: z.object({
+      id: z.string().openapi({ param: { name: 'id', in: 'path' } }),
+      keyId: z.string().openapi({ param: { name: 'keyId', in: 'path' } }),
+    }),
+  },
+  responses: {
+    200: { description: 'Key revoked', content: { 'application/json': { schema: z.object({ status: z.literal('revoked'), message: z.string() }) } } },
+    401: { description: 'Not authenticated', content: { 'application/json': { schema: ErrorResponse } } },
+    404: { description: 'Key not found', content: { 'application/json': { schema: ErrorResponse } } },
+  },
+}), (c) => c.json({} as never))
+
 // --- Query ---
 
 docs.openapi(createRoute({
@@ -580,6 +657,7 @@ docs.doc('/api/openapi.json', {
     { name: 'Compliance', description: 'Guardrails and violation tracking' },
     { name: 'Conversations', description: 'Conversation lifecycle, messages, and analytics' },
     { name: 'Connectors', description: 'Connect MCP servers and Slack bots' },
+    { name: 'API Keys', description: 'Workspace API keys for programmatic and MCP access' },
     { name: 'Query', description: 'Send queries to workspace agents' },
   ],
   security: [],

--- a/src/routes/api-keys.test.ts
+++ b/src/routes/api-keys.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import { createHash } from 'crypto'
+
+// Mock config to avoid requiring real env vars
+vi.mock('../config.js', () => ({
+  JWT_SECRET: 'test-secret-that-is-at-least-32-chars-long',
+  PORT: 3001,
+  CORS_ORIGINS: ['http://localhost:4322'],
+  DASHBOARD_URL: 'http://localhost:4322',
+  IS_PRODUCTION: false,
+  DEFAULT_MODEL: 'claude-3-5-sonnet-20241022',
+}))
+
+// Mock pool to avoid DB dependencies
+const mockExecute = vi.fn()
+vi.mock('../db/pool.js', () => ({
+  getPool: vi.fn(() => ({ execute: mockExecute })),
+}))
+
+// Mock requireAuth to always pass — route auth is tested separately
+vi.mock('../middleware/auth.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../middleware/auth.js')>()
+  return {
+    ...actual,
+    requireAuth: vi.fn((_c: unknown, next: () => Promise<void>) => next()),
+  }
+})
+
+const apiKeysRouter = (await import('./api-keys.js')).default
+const { requireApiKey } = await import('../middleware/auth.js')
+import type { ApiKeyEnv } from '../middleware/auth.js'
+
+// ── requireApiKey middleware ─────────────────────────────────────────
+
+describe('requireApiKey', () => {
+  function createTestApp() {
+    const app = new Hono<ApiKeyEnv>()
+    app.use('*', requireApiKey)
+    app.get('/test', (c) => c.json({ workspace_id: c.get('workspace_id'), is_test: c.get('is_test_key') }))
+    return app
+  }
+
+  beforeEach(() => {
+    mockExecute.mockReset()
+  })
+
+  it('returns 401 when Authorization header is missing', async () => {
+    const app = createTestApp()
+    const res = await app.request('/test')
+    expect(res.status).toBe(401)
+    const body = await res.json()
+    expect(body.error).toBe('API key required')
+  })
+
+  it('returns 401 when Authorization header is not Bearer', async () => {
+    const app = createTestApp()
+    const res = await app.request('/test', { headers: { Authorization: 'Basic abc123' } })
+    expect(res.status).toBe(401)
+    expect((await res.json()).error).toBe('API key required')
+  })
+
+  it('returns 401 for invalid key prefix', async () => {
+    const app = createTestApp()
+    const res = await app.request('/test', { headers: { Authorization: 'Bearer invalid_key_12345' } })
+    expect(res.status).toBe(401)
+    expect((await res.json()).error).toBe('Invalid API key format')
+  })
+
+  it('returns 401 when key is not found in DB', async () => {
+    mockExecute.mockResolvedValueOnce([[]])
+    const app = createTestApp()
+    const res = await app.request('/test', { headers: { Authorization: 'Bearer sp_live_notfound' } })
+    expect(res.status).toBe(401)
+    expect((await res.json()).error).toBe('Invalid API key')
+  })
+
+  it('returns 401 for a revoked key', async () => {
+    mockExecute.mockResolvedValueOnce([[{ id: 'key-1', workspace_id: 'ws-1', revoked_at: '2026-01-01' }]])
+    const app = createTestApp()
+    const res = await app.request('/test', { headers: { Authorization: 'Bearer sp_live_revokedkey1234' } })
+    expect(res.status).toBe(401)
+    expect((await res.json()).error).toBe('API key has been revoked')
+  })
+
+  it('passes through with a valid sp_live_ key and sets context', async () => {
+    mockExecute
+      .mockResolvedValueOnce([[{ id: 'key-1', workspace_id: 'ws-abc', revoked_at: null }]])
+      .mockResolvedValueOnce([{ affectedRows: 1 }]) // last_used_at update
+    const app = createTestApp()
+    const key = 'sp_live_' + 'a'.repeat(64)
+    const res = await app.request('/test', { headers: { Authorization: `Bearer ${key}` } })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.workspace_id).toBe('ws-abc')
+    expect(body.is_test).toBe(false)
+  })
+
+  it('sets is_test_key true for sp_test_ keys', async () => {
+    mockExecute
+      .mockResolvedValueOnce([[{ id: 'key-2', workspace_id: 'ws-xyz', revoked_at: null }]])
+      .mockResolvedValueOnce([{ affectedRows: 1 }])
+    const app = createTestApp()
+    const key = 'sp_test_' + 'b'.repeat(64)
+    const res = await app.request('/test', { headers: { Authorization: `Bearer ${key}` } })
+    expect(res.status).toBe(200)
+    expect((await res.json()).is_test).toBe(true)
+  })
+
+  it('hashes the key before querying DB', async () => {
+    mockExecute.mockResolvedValueOnce([[]])
+    const app = createTestApp()
+    const key = 'sp_live_' + 'c'.repeat(64)
+    await app.request('/test', { headers: { Authorization: `Bearer ${key}` } })
+    const queriedHash = mockExecute.mock.calls[0][1][0]
+    const expectedHash = createHash('sha256').update(key).digest('hex')
+    expect(queriedHash).toBe(expectedHash)
+  })
+})
+
+// ── API key routes ───────────────────────────────────────────────────
+
+describe('POST /api/workspaces/:id/api-keys', () => {
+  beforeEach(() => mockExecute.mockReset())
+
+  it('creates a key and returns it once', async () => {
+    mockExecute
+      .mockResolvedValueOnce([[{ id: 'ws-1' }]]) // workspace lookup
+      .mockResolvedValueOnce([{ affectedRows: 1 }]) // insert
+
+    const res = await apiKeysRouter.request('/api/workspaces/ws-1/api-keys', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ label: 'My integration' }),
+    })
+
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.key).toMatch(/^sp_live_[0-9a-f]{64}$/)
+    expect(body.prefix).toBe(body.key.slice(0, 16))
+    expect(body.label).toBe('My integration')
+    expect(body.id).toBeDefined()
+  })
+
+  it('creates a test key when test: true', async () => {
+    mockExecute
+      .mockResolvedValueOnce([[{ id: 'ws-1' }]])
+      .mockResolvedValueOnce([{ affectedRows: 1 }])
+
+    const res = await apiKeysRouter.request('/api/workspaces/ws-1/api-keys', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ label: 'Test key', test: true }),
+    })
+
+    const body = await res.json()
+    expect(body.key).toMatch(/^sp_test_/)
+  })
+
+  it('returns 404 for unknown workspace', async () => {
+    mockExecute.mockResolvedValueOnce([[]])
+    const res = await apiKeysRouter.request('/api/workspaces/unknown/api-keys', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ label: 'Key' }),
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 400 when label is missing', async () => {
+    mockExecute.mockResolvedValueOnce([[{ id: 'ws-1' }]])
+    const res = await apiKeysRouter.request('/api/workspaces/ws-1/api-keys', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('GET /api/workspaces/:id/api-keys', () => {
+  beforeEach(() => mockExecute.mockReset())
+
+  it('lists active keys without raw key values', async () => {
+    mockExecute
+      .mockResolvedValueOnce([[{ id: 'ws-1' }]])
+      .mockResolvedValueOnce([[
+        { id: 'k1', key_prefix: 'sp_live_abcd12', label: 'Integration', created_at: '2026-04-27', last_used_at: null },
+      ]])
+
+    const res = await apiKeysRouter.request('/api/workspaces/ws-1/api-keys')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.keys).toHaveLength(1)
+    expect(body.keys[0].prefix).toBe('sp_live_abcd12')
+    expect(body.keys[0]).not.toHaveProperty('key')
+    expect(body.keys[0]).not.toHaveProperty('key_hash')
+  })
+
+  it('returns empty array when no keys exist', async () => {
+    mockExecute.mockResolvedValueOnce([[{ id: 'ws-1' }]]).mockResolvedValueOnce([[]])
+    const res = await apiKeysRouter.request('/api/workspaces/ws-1/api-keys')
+    expect(res.status).toBe(200)
+    expect((await res.json()).keys).toHaveLength(0)
+  })
+
+  it('returns 404 for unknown workspace', async () => {
+    mockExecute.mockResolvedValueOnce([[]])
+    const res = await apiKeysRouter.request('/api/workspaces/unknown/api-keys')
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('DELETE /api/workspaces/:id/api-keys/:keyId', () => {
+  beforeEach(() => mockExecute.mockReset())
+
+  it('revokes an active key', async () => {
+    mockExecute
+      .mockResolvedValueOnce([[{ id: 'k1' }]]) // key lookup
+      .mockResolvedValueOnce([{ affectedRows: 1 }]) // update
+
+    const res = await apiKeysRouter.request('/api/workspaces/ws-1/api-keys/k1', { method: 'DELETE' })
+    expect(res.status).toBe(200)
+    expect((await res.json()).status).toBe('revoked')
+  })
+
+  it('returns 404 when key does not exist', async () => {
+    mockExecute.mockResolvedValueOnce([[]])
+    const res = await apiKeysRouter.request('/api/workspaces/ws-1/api-keys/nope', { method: 'DELETE' })
+    expect(res.status).toBe(404)
+  })
+})

--- a/src/routes/api-keys.ts
+++ b/src/routes/api-keys.ts
@@ -1,0 +1,75 @@
+import { Hono } from 'hono'
+import { randomBytes, createHash } from 'crypto'
+import { z } from 'zod'
+import { getPool } from '../db/pool.js'
+import { parseBody } from '../middleware/validate.js'
+import { requireAuth, type AuthEnv } from '../middleware/auth.js'
+import type { ApiKeyRow, IdRow } from '../db/types.js'
+
+const createKeySchema = z.object({
+  label: z.string().min(1, 'Label is required').max(255),
+  test: z.boolean().optional(),
+})
+
+const apiKeys = new Hono<AuthEnv>()
+
+apiKeys.use('/api/workspaces/:id/api-keys', requireAuth)
+apiKeys.use('/api/workspaces/:id/api-keys/*', requireAuth)
+
+apiKeys.post('/api/workspaces/:id/api-keys', async (c) => {
+  const db = getPool()
+  const workspaceId = c.req.param('id')
+
+  const [wsRows] = await db.execute<IdRow[]>('SELECT id FROM workspaces WHERE id = ?', [workspaceId])
+  if (!wsRows[0]) return c.json({ error: 'Workspace not found' }, 404)
+
+  const result = await parseBody(c, createKeySchema)
+  if (!result.success) return result.response
+
+  const { label, test } = result.data
+  const prefix = test ? 'sp_test_' : 'sp_live_'
+  const key = `${prefix}${randomBytes(32).toString('hex')}`
+  const keyHash = createHash('sha256').update(key).digest('hex')
+  const keyPrefix = key.slice(0, 16)
+  const id = randomBytes(16).toString('hex')
+
+  await db.execute(
+    'INSERT INTO api_keys (id, workspace_id, key_hash, key_prefix, label) VALUES (?, ?, ?, ?, ?)',
+    [id, workspaceId, keyHash, keyPrefix, label]
+  )
+
+  return c.json({ id, key, prefix: keyPrefix, label, created_at: new Date().toISOString() }, 201)
+})
+
+apiKeys.get('/api/workspaces/:id/api-keys', async (c) => {
+  const db = getPool()
+  const workspaceId = c.req.param('id')
+
+  const [wsRows] = await db.execute<IdRow[]>('SELECT id FROM workspaces WHERE id = ?', [workspaceId])
+  if (!wsRows[0]) return c.json({ error: 'Workspace not found' }, 404)
+
+  const [rows] = await db.execute<ApiKeyRow[]>(
+    'SELECT id, key_prefix, label, created_at, last_used_at FROM api_keys WHERE workspace_id = ? AND revoked_at IS NULL ORDER BY created_at DESC',
+    [workspaceId]
+  )
+
+  return c.json({ keys: rows.map((k) => ({ id: k.id, prefix: k.key_prefix, label: k.label, created_at: k.created_at, last_used_at: k.last_used_at })) })
+})
+
+apiKeys.delete('/api/workspaces/:id/api-keys/:keyId', async (c) => {
+  const db = getPool()
+  const workspaceId = c.req.param('id')
+  const keyId = c.req.param('keyId')
+
+  const [rows] = await db.execute<ApiKeyRow[]>(
+    'SELECT id FROM api_keys WHERE id = ? AND workspace_id = ? AND revoked_at IS NULL',
+    [keyId, workspaceId]
+  )
+  if (!rows[0]) return c.json({ error: 'API key not found' }, 404)
+
+  await db.execute('UPDATE api_keys SET revoked_at = NOW() WHERE id = ?', [keyId])
+
+  return c.json({ status: 'revoked', message: 'API key revoked.' })
+})
+
+export default apiKeys


### PR DESCRIPTION
## Summary

- Adds `api_keys` table (migration 6) with SHA-256 hashed key storage — the raw key is never persisted
- Implements three management routes behind `requireAuth`: create, list, revoke
- Adds `requireApiKey` middleware and `ApiKeyEnv` type, ready for the MCP server to use on the query path

## Key design

Keys follow the format `sp_live_<64 hex chars>` (or `sp_test_` for test/staging). Only the SHA-256 hash and a display prefix (`sp_live_abcd1234...`) are stored. The full key is returned exactly once on creation.

`sp_test_` keys signal test mode — rate limits and billing will not apply when the MCP server honours this in a later story.

## Test plan

- `pnpm build` — TypeScript compiles clean ✓
- `pnpm test` — all 19 tests pass ✓
- Start the server: migration 6 runs, `api_keys` table is created
- `POST /api/workspaces/:id/api-keys` with `{ "label": "my key" }` returns `{ id, key, prefix, label, created_at }`
- `GET /api/workspaces/:id/api-keys` returns the key metadata (no raw key)
- `DELETE /api/workspaces/:id/api-keys/:keyId` soft-revokes the key
- Subsequent `GET` excludes revoked keys

### Cross-repo impact

- SDK update: yes — `feat/api-key-management` branch on `supaproxy-sdk` adds matching `api.workspaces.apiKeys.*` methods
- Breaking change: no

Closes #25