### PR TITLE
fix: add missing fraud_indicators column to conversation_stats

### DIFF
--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -325,6 +325,16 @@ const migrations: Migration[] = [
       }
     },
   },
+  {
+    version: 6,
+    name: 'add fraud_indicators to conversation_stats',
+    up: async (pool) => {
+      const [cols] = await pool.execute<ColumnInfoRow[]>("SHOW COLUMNS FROM conversation_stats LIKE 'fraud_indicators'");
+      if (cols.length === 0) {
+        await pool.execute("ALTER TABLE conversation_stats ADD COLUMN fraud_indicators JSON AFTER knowledge_gaps");
+      }
+    },
+  },
 ];
 
 interface SchemaMigrationRow extends mysql.RowDataPacket {


### PR DESCRIPTION
## Summary
- The conversations list query selects `cs.fraud_indicators` but the column was never added in migrations
- This causes a 500 Internal Server Error on `GET /api/workspaces/:id/conversations`
- Add migration v6 to add the column

## Root cause
The `fraud_indicators` column was defined in the shared types and query code but never included in the original `conversation_stats` CREATE TABLE or a subsequent migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)