### PR TITLE
fix: make DASHBOARD_URL a required env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@ JWT_SECRET=
 # Server
 PORT=3001
 CORS_ORIGINS=http://localhost:4322,http://localhost:3001
-# DASHBOARD_URL=http://localhost:4322
+DASHBOARD_URL=http://localhost:4322
 
 # MySQL
 # Local dev (Docker mapped to host port 3308):

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,7 +23,7 @@ export const JWT_SECRET = (() => {
   return secret
 })()
 export const CORS_ORIGINS = requireEnv('CORS_ORIGINS').split(',')
-export const DASHBOARD_URL = process.env.DASHBOARD_URL || ''
+export const DASHBOARD_URL = requireEnv('DASHBOARD_URL')
 
 // Cookie domain — derived from DASHBOARD_URL so cookies work across subdomains
 // e.g. https://supaproxy.cloud → .supaproxy.cloud

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -121,19 +121,19 @@ auth.post('/api/auth/login', async (c) => {
   }
 
   if (!email || !password) {
-    if (isFormSubmit && DASHBOARD_URL) return c.redirect(`${DASHBOARD_URL}/login?error=missing_fields`)
+    if (isFormSubmit) return c.redirect(`${DASHBOARD_URL}/login?error=missing_fields`)
     return c.json({ error: 'Email and password are required.' }, 400)
   }
 
   const user = await findUserByEmail(email)
   if (!user) {
-    if (isFormSubmit && DASHBOARD_URL) return c.redirect(`${DASHBOARD_URL}/login?error=invalid_credentials`)
+    if (isFormSubmit) return c.redirect(`${DASHBOARD_URL}/login?error=invalid_credentials`)
     return c.json({ error: 'Invalid credentials.' }, 401)
   }
 
   const valid = await verifyPassword(password, user.password_hash)
   if (!valid) {
-    if (isFormSubmit && DASHBOARD_URL) return c.redirect(`${DASHBOARD_URL}/login?error=invalid_credentials`)
+    if (isFormSubmit) return c.redirect(`${DASHBOARD_URL}/login?error=invalid_credentials`)
     return c.json({ error: 'Invalid credentials.' }, 401)
   }
 
@@ -152,7 +152,7 @@ auth.post('/api/auth/login', async (c) => {
     ...(COOKIE_DOMAIN && { domain: COOKIE_DOMAIN }),
   })
 
-  if (isFormSubmit && DASHBOARD_URL) return c.redirect(`${DASHBOARD_URL}/workspaces`)
+  if (isFormSubmit) return c.redirect(`${DASHBOARD_URL}/workspaces`)
   return c.json({
     status: 'ok',
     user: { id: user.id, email: user.email, name: user.name, role: user.org_role },
@@ -183,8 +183,7 @@ auth.get('/api/auth/session', (c) => {
 // --- Logout ---
 auth.get('/api/auth/logout', (c) => {
   setCookie(c, 'supaproxy_session', '', { path: '/', maxAge: 0, ...(COOKIE_DOMAIN && { domain: COOKIE_DOMAIN }) })
-  if (DASHBOARD_URL) return c.redirect(`${DASHBOARD_URL}/login`)
-  return c.json({ status: 'ok' })
+  return c.redirect(`${DASHBOARD_URL}/login`)
 })
 
 export default auth


### PR DESCRIPTION
## Summary
- `DASHBOARD_URL` is now required via `requireEnv()` — server won't start without it
- Remove all `if (DASHBOARD_URL)` conditional checks in auth routes
- Login always redirects on form submit, logout always redirects
- Update `.env.example` to show it's required (uncommented)

Without `DASHBOARD_URL`, login returns JSON instead of redirecting, logout returns JSON, and cookie domain is undefined. That's a broken setup, not an optional feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)