### PR TITLE
refactor: composable server for cloud overlay

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "license": "MIT",
   "type": "module",
+  "exports": {
+    "./server": "./src/server.ts"
+  },
   "description": "AI operations engine. Route any LLM to any team through one governed layer.",
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,72 @@
+/**
+ * App factory — creates the Hono app with all routes mounted.
+ *
+ * This is the composable entry point that both the open-source
+ * server and the cloud overlay use. The cloud overlay can mount
+ * additional routes after calling this.
+ */
+import { Hono } from 'hono'
+import { cors } from 'hono/cors'
+import { getCookie } from 'hono/cookie'
+import pino from 'pino'
+import type { Container } from './container.js'
+import { CORS_ORIGINS } from './config.js'
+import docs from './openapi.js'
+
+const log = pino({ name: 'supaproxy' })
+
+export function createApp(container: Container, corsOrigins?: string[]): Hono {
+  const app = new Hono()
+
+  app.use('*', cors({
+    origin: (origin) => {
+      const origins = corsOrigins ?? CORS_ORIGINS
+      return origins.includes(origin) ? origin : origins[0]
+    },
+    credentials: true,
+  }))
+
+  app.onError((err, c) => {
+    log.error({ error: err.message, stack: err.stack }, 'Unhandled error')
+    return c.json({ error: 'Internal Server Error' }, 500)
+  })
+
+  // Health check
+  app.get('/health', async (c) => {
+    try {
+      const token = getCookie(c, 'supaproxy_session')
+      const payload = token ? container.tokenService.verify(token) : null
+      if (!payload) return c.json({ status: 'ok' })
+      const result = await container.getHealthUseCase.executeAuthenticated()
+      return c.json(result)
+    } catch (err) {
+      log.error({ error: (err as Error).message }, 'Health check failed')
+      return c.json({ status: 'error' }, 500)
+    }
+  })
+
+  // Models
+  app.get('/api/models', async (c) => {
+    const models = await container.getModelsUseCase.execute()
+    return c.json({ models })
+  })
+
+  // Consumer types
+  app.get('/api/consumers/types', (c) => {
+    return c.json({ consumers: container.consumerRegistry.schemas() })
+  })
+
+  // Route modules
+  app.route('/', container.authRoutes)
+  app.route('/', container.orgRoutes)
+  app.route('/', container.queueRoutes)
+  app.route('/', container.workspaceRoutes)
+  app.route('/', container.conversationRoutes)
+  app.route('/', container.connectorRoutes)
+  app.route('/', container.queryRoutes)
+
+  // API docs
+  app.route('/', docs)
+
+  return app
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,21 @@
+/**
+ * Open-source server entry point.
+ *
+ * Uses the composable pieces directly — no cloud overlay.
+ * Single-tenant mode (NoOpTenantService is the default).
+ *
+ * The cloud overlay (supaproxy-cloud) imports from ./server.ts
+ * and injects CloudTenantService + additional routes.
+ */
 import 'dotenv/config'
 import { serve } from '@hono/node-server'
-import { Hono } from 'hono'
-import { cors } from 'hono/cors'
-import { getCookie } from 'hono/cookie'
 import pino from 'pino'
 import { getPool } from './db/pool.js'
 import { runMigrations } from './db/migrations.js'
-import { CORS_ORIGINS, DASHBOARD_URL, PORT } from './config.js'
 import { createContainer } from './container.js'
-import docs from './openapi.js'
+import { createApp } from './app.js'
+import { startConsumers, startWorkers } from './startup.js'
+import { PORT, DASHBOARD_URL } from './config.js'
 
 const log = pino({ name: 'supaproxy' })
 
@@ -16,58 +23,11 @@ const log = pino({ name: 'supaproxy' })
 const pool = getPool()
 await runMigrations(pool)
 
-// --- Composition root ---
+// --- Composition root (single-tenant, no options needed) ---
 const container = createContainer(pool)
 
-// --- Hono app ---
-const app = new Hono()
-app.use('*', cors({
-  origin: (origin) => CORS_ORIGINS.includes(origin) ? origin : CORS_ORIGINS[0],
-  credentials: true,
-}))
-app.onError((err, c) => {
-  log.error({ error: err.message, stack: err.stack }, 'Unhandled error')
-  return c.json({ error: 'Internal Server Error' }, 500)
-})
-
-// Health check
-app.get('/health', async (c) => {
-  try {
-    const token = getCookie(c, 'supaproxy_session')
-    const payload = token ? container.tokenService.verify(token) : null
-
-    if (!payload) return c.json({ status: 'ok' })
-
-    const result = await container.getHealthUseCase.executeAuthenticated()
-    return c.json(result)
-  } catch (err) {
-    log.error({ error: (err as Error).message }, 'Health check failed')
-    return c.json({ status: 'error' }, 500)
-  }
-})
-
-// Models endpoint
-app.get('/api/models', async (c) => {
-  const models = await container.getModelsUseCase.execute()
-  return c.json({ models })
-})
-
-// Consumer types endpoint — dashboard discovers available consumers from this
-app.get('/api/consumers/types', (c) => {
-  return c.json({ consumers: container.consumerRegistry.schemas() })
-})
-
-// Mount route modules
-app.route('/', container.authRoutes)
-app.route('/', container.orgRoutes)
-app.route('/', container.queueRoutes)
-app.route('/', container.workspaceRoutes)
-app.route('/', container.conversationRoutes)
-app.route('/', container.connectorRoutes)
-app.route('/', container.queryRoutes)
-
-// API docs (mounted last)
-app.route('/', docs)
+// --- App ---
+const app = createApp(container)
 
 // --- Start ---
 const workspaceCount = await container.workspaceRepo.getActiveWorkspaceCount()
@@ -77,48 +37,6 @@ serve({ fetch: app.fetch, port: PORT }, async () => {
   log.info({ port: PORT }, 'SupaProxy API listening')
   log.info({ dashboard: DASHBOARD_URL }, 'Dashboard URL')
 
-  // Start Slack consumer via plugin registry
-  try {
-    const botToken = await container.orgRepo.getSettingValue('slack_bot_token')
-    const appToken = await container.orgRepo.getSettingValue('slack_app_token')
-    if (botToken && appToken && container.consumerRegistry.has('slack')) {
-      const plugin = container.consumerRegistry.get('slack')
-      await plugin.start({
-        onMessage: async (msg: import('@supaproxy/consumers').IncomingMessage) => {
-          const result = await container.executeQueryUseCase.execute(msg.channel, msg.query, {
-            consumerType: msg.consumerType,
-            channel: msg.channel,
-            userId: msg.userId,
-            userName: msg.userName,
-            sessionId: msg.threadId,
-          })
-          return { answer: result.answer, conversationId: result.conversationId || '' }
-        },
-        onError: (err: Error) => log.error({ error: err.message }, 'Consumer error'),
-        logger: log,
-        getWorkspaceForChannel: async (channelId: string): Promise<import('@supaproxy/consumers').Workspace | null> => {
-          const consumers = await container.workspaceRepo.findActiveSlackConsumers()
-          for (const row of consumers) {
-            const cfg = typeof row.config === 'string' ? JSON.parse(row.config) : row.config
-            if ((cfg.channels || []).includes(channelId)) return { id: row.workspace_id, name: '' }
-          }
-          return null
-        },
-      }, { bot_token: botToken, app_token: appToken })
-
-      // Register poster for outbound messages
-      container.posterRegistry.register('slack', async (target, text) => {
-        const threadTs = target.externalThreadId?.split(':')[1]
-        if (target.channel && threadTs) await plugin.sendMessage(target.channel, text, threadTs)
-      })
-      log.info('Slack consumer started via plugin')
-    } else {
-      log.info('Slack bot not configured — set tokens in Settings > Integrations')
-    }
-  } catch (err) {
-    log.warn({ error: (err as Error).message }, 'Slack consumer failed — server continues without it')
-  }
-
-  // Start lifecycle workers
-  await container.queueService.startWorkers(container.lifecycleUseCase)
+  await startConsumers(container)
+  await startWorkers(container)
 })

--- a/src/infrastructure/tenant/NoOpTenantService.test.ts
+++ b/src/infrastructure/tenant/NoOpTenantService.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { NoOpTenantService } from './NoOpTenantService.js'
+
+describe('NoOpTenantService', () => {
+  const service = new NoOpTenantService()
+
+  it('scopeWorkspaceList returns null (no filtering)', () => {
+    expect(service.scopeWorkspaceList('org-1')).toBeNull()
+  })
+
+  it('verifyWorkspaceAccess does not throw for any input', () => {
+    expect(() => service.verifyWorkspaceAccess('org-1', 'org-2')).not.toThrow()
+    expect(() => service.verifyWorkspaceAccess(null, 'org-1')).not.toThrow()
+    expect(() => service.verifyWorkspaceAccess('org-1', 'org-1')).not.toThrow()
+  })
+
+  it('resolveOrgForCreation returns the user org', () => {
+    expect(service.resolveOrgForCreation('org-abc')).toBe('org-abc')
+  })
+})

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,16 @@
+/**
+ * Public API for supaproxy-server.
+ *
+ * This is what the cloud overlay imports:
+ *
+ *   import { createContainer, createApp, startConsumers, startWorkers, getPool, runMigrations } from 'supaproxy-server'
+ *
+ * The open-source index.ts uses these same functions directly.
+ */
+export { createContainer, type Container } from './container.js'
+export { createApp } from './app.js'
+export { startConsumers, startWorkers } from './startup.js'
+export { getPool } from './db/pool.js'
+export { runMigrations } from './db/migrations.js'
+export { PORT, CORS_ORIGINS, DASHBOARD_URL } from './config.js'
+export type { TenantService } from './application/ports/TenantService.js'

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -1,0 +1,58 @@
+/**
+ * Startup routines — consumer boot, lifecycle workers.
+ *
+ * Separated from app creation so the cloud overlay can
+ * hook into the startup sequence.
+ */
+import pino from 'pino'
+import type { Container } from './container.js'
+import type { IncomingMessage, Workspace } from '@supaproxy/consumers'
+
+const log = pino({ name: 'startup' })
+
+export async function startConsumers(container: Container): Promise<void> {
+  try {
+    const botToken = await container.orgRepo.getSettingValue('slack_bot_token')
+    const appToken = await container.orgRepo.getSettingValue('slack_app_token')
+
+    if (botToken && appToken && container.consumerRegistry.has('slack')) {
+      const plugin = container.consumerRegistry.get('slack')
+      await plugin.start({
+        onMessage: async (msg: IncomingMessage) => {
+          const result = await container.executeQueryUseCase.execute(msg.channel, msg.query, {
+            consumerType: msg.consumerType,
+            channel: msg.channel,
+            userId: msg.userId,
+            userName: msg.userName,
+            sessionId: msg.threadId,
+          })
+          return { answer: result.answer, conversationId: result.conversationId || '' }
+        },
+        onError: (err: Error) => log.error({ error: err.message }, 'Consumer error'),
+        logger: log,
+        getWorkspaceForChannel: async (channelId: string): Promise<Workspace | null> => {
+          const consumers = await container.workspaceRepo.findActiveSlackConsumers()
+          for (const row of consumers) {
+            const cfg = typeof row.config === 'string' ? JSON.parse(row.config) : row.config
+            if ((cfg.channels || []).includes(channelId)) return { id: row.workspace_id, name: '' }
+          }
+          return null
+        },
+      }, { bot_token: botToken, app_token: appToken })
+
+      container.posterRegistry.register('slack', async (target, text) => {
+        const threadTs = target.externalThreadId?.split(':')[1]
+        if (target.channel && threadTs) await plugin.sendMessage(target.channel, text, threadTs)
+      })
+      log.info('Slack consumer started via plugin')
+    } else {
+      log.info('Slack bot not configured — set tokens in Settings > Integrations')
+    }
+  } catch (err) {
+    log.warn({ error: (err as Error).message }, 'Slack consumer failed — server continues without it')
+  }
+}
+
+export async function startWorkers(container: Container): Promise<void> {
+  await container.queueService.startWorkers(container.lifecycleUseCase)
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -38,9 +38,13 @@ export default defineConfig({
         // ExecuteQueryUseCase is the AI agent loop; requires integration-level mocking
         'src/application/query/ExecuteQueryUseCase.ts',
 
-        // Composition root and entrypoint (integration-level, not unit-testable)
+        // Composition root, entrypoints, and runtime wiring (integration-level)
         'src/container.ts',
         'src/index.ts',
+        'src/app.ts',
+        'src/server.ts',
+        'src/startup.ts',
+        'src/config.ts',
         'src/openapi.ts',
 
         // Database setup (requires live MySQL)


### PR DESCRIPTION
## Summary

Refactor the server entry point into composable pieces that external overlays can import and extend.

**New files:**
- `app.ts` — `createApp(container)` creates the Hono app with all routes
- `startup.ts` — `startConsumers()`, `startWorkers()` boot sequence
- `server.ts` — public API exporting all composable pieces

**Modified:**
- `index.ts` — simplified to 30 lines using the composable pieces
- `package.json` — added `exports` field for `supaproxy-server/server` subpath

**How an overlay uses this:**
```typescript
import { createContainer, createApp, startConsumers, startWorkers } from 'supaproxy-server/server'

const container = createContainer(pool, { tenantService: myTenantService })
const app = createApp(container)
// mount additional routes on app
```

## Test plan
- [x] All 149 tests pass
- [x] Server builds independently
- [ ] Server starts normally (`pnpm dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)