### PR TITLE
feat: provider types endpoint + migration

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -56,6 +56,11 @@ export function createApp(container: Container, corsOrigins?: string[]): Hono {
     return c.json({ consumers: container.consumerRegistry.schemas() })
   })
 
+  // Provider types
+  app.get('/api/providers/types', (c) => {
+    return c.json({ providers: container.providerRegistry.schemas() })
+  })
+
   // Route modules
   app.route('/', container.authRoutes)
   app.route('/', container.orgRoutes)

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -1,6 +1,7 @@
 import mysql from 'mysql2/promise';
 import pino from 'pino';
 import type { ColumnInfoRow } from './types.js';
+import { generateId } from '../domain/shared/EntityId.js';
 
 const log = pino({ name: 'migrations' });
 
@@ -366,6 +367,23 @@ const migrations: Migration[] = [
   },
   {
     version: 8,
+    name: 'set default ai_provider_type for existing orgs',
+    up: async (pool) => {
+      // Ensure existing orgs have ai_provider_type set so the provider
+      // resolution doesn't throw. New orgs will set this during setup.
+      const [orgs] = await pool.execute<mysql.RowDataPacket[]>(
+        `SELECT id FROM organisations WHERE id NOT IN (SELECT org_id FROM org_settings WHERE key_name = 'ai_provider_type')`
+      );
+      for (const org of orgs) {
+        await pool.execute(
+          `INSERT INTO org_settings (id, org_id, key_name, value, is_secret) VALUES (?, ?, 'ai_provider_type', 'anthropic', 0)`,
+          [generateId(), org.id]
+        );
+      }
+    },
+  },
+  {
+    version: 9,
     name: 'add unique constraint on teams (org_id, name)',
     up: async (pool) => {
       // Deduplicate any existing duplicates first (keep the earliest)

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -386,7 +386,12 @@ const migrations: Migration[] = [
     version: 9,
     name: 'add unique constraint on teams (org_id, name)',
     up: async (pool) => {
-      // Deduplicate any existing duplicates first (keep the earliest)
+      // Check if constraint already exists (may have been applied as old migration 8)
+      const [rows] = await pool.execute<mysql.RowDataPacket[]>(
+        `SELECT COUNT(*) as cnt FROM information_schema.TABLE_CONSTRAINTS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'teams' AND CONSTRAINT_NAME = 'unique_org_team'`
+      );
+      if (rows[0]?.cnt > 0) return; // Already exists
+
       await pool.execute(`
         DELETE t1 FROM teams t1
         INNER JOIN teams t2


### PR DESCRIPTION
## Summary

- New `GET /api/providers/types` endpoint returns provider registry schemas for dashboard provider selection
- Migration sets `ai_provider_type = 'anthropic'` for existing orgs so provider resolution works on upgrade

Closes #42 (server side)

## Test plan
- [x] Build passes
- [x] All tests pass
- [x] Endpoint returns Anthropic + OpenAI provider schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)