### PR TITLE
feat: input guardrail screening pipeline

### DIFF
--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -1,0 +1,115 @@
+# Guardrails
+
+Guardrails are the screening layer that sits between consumers and the LLM. They intercept queries and responses to detect, redact, or block sensitive content before it leaves your infrastructure.
+
+## Pipeline stages
+
+Guardrails run at two points in the conversation flow:
+
+| Stage | When | What it screens | Example |
+|---|---|---|---|
+| `pre-llm` | After user sends query, before LLM receives it | User input | PII, credentials, IP, confidential data |
+| `post-llm` | After LLM responds, before user receives it | Model output | Hallucinations, toxic content, brand violations |
+
+Each stage supports multiple guardrails chained in sequence. The first `block` stops the chain. Redactions accumulate through the chain.
+
+## Actions
+
+| Action | What happens |
+|---|---|
+| `pass` | No issue detected. Content forwarded unchanged. |
+| `redact` | Sensitive tokens replaced with `[REDACTED:category]`. Sanitised version forwarded. |
+| `block` | Content rejected. User receives an explanation. Nothing forwarded. |
+
+## Built-in guardrails (open source)
+
+### PatternInputGuardrail
+
+Regex and token matching. No model required, no data egress. Covers:
+- South African ID numbers
+- Credit card numbers (Luhn-validated)
+- Email addresses
+- Phone numbers
+- Custom regex patterns per workspace
+
+### LlmInputGuardrail
+
+Calls any OpenAI-compatible endpoint to classify the query. Self-hosters point this at Ollama, a private Azure deployment, or any locally-hosted model. The screening happens privately before the query reaches the public LLM.
+
+## Marketplace guardrails
+
+Third-party guardrails install via the marketplace. They register as pipeline plugins with a `pre-llm` or `post-llm` stage and run as part of the guardrail chain.
+
+Example marketplace plugins:
+- **Redact** (by Numstack) - Advanced PII detection with ML-based entity recognition
+- **Safety** (by Numstack) - Output validation for hallucinations, toxicity, brand voice
+
+## Events
+
+Every guardrail screening emits events that marketplace products can subscribe to via hooks:
+
+| Event | When | Payload |
+|---|---|---|
+| `guardrail.triggered` | Any non-pass result | source, action, categories, confidence |
+| `guardrail.blocked` | Query blocked | source, categories, message |
+| `guardrail.redacted` | Content redacted | source, categories, redacted fields |
+
+### Why events matter
+
+Events connect guardrails to the broader product ecosystem:
+
+- **Sherlock** subscribes to `guardrail.triggered` - blocked queries are a fraud signal (user may be attempting data exfiltration)
+- **Abide** subscribes to `guardrail.blocked` - a blocked query could indicate a policy violation worth logging for compliance
+- **Audit** subscribes to all guardrail events - every screening decision is part of the immutable compliance trail
+
+## Guardrail chain execution
+
+```
+User query
+  │
+  ▼
+┌─────────────────────┐
+│ PatternInputGuardrail│ ── regex/token matching (fast, no external calls)
+└──────────┬──────────┘
+           │ pass or redacted query
+           ▼
+┌─────────────────────┐
+│ LlmInputGuardrail   │ ── calls private model endpoint (deeper analysis)
+└──────────┬──────────┘
+           │ pass or redacted query
+           ▼
+┌─────────────────────┐
+│ Marketplace plugins  │ ── installed guardrails run in install order
+└──────────┬──────────┘
+           │
+           ▼
+       Forward to LLM (or block)
+```
+
+1. Each guardrail receives the output of the previous one
+2. First `block` stops the entire chain
+3. Redactions accumulate through the chain
+4. Events emitted after each guardrail completes
+5. All results logged to audit trail (original query preserved)
+
+## Audit logging
+
+When a query is screened, three fields are added to the audit log:
+
+| Field | Type | Description |
+|---|---|---|
+| `input_screening_action` | `pass`, `redact`, `block`, or `null` | Final action taken |
+| `input_screening_categories` | `string[]` or `null` | All detected categories across the chain |
+| `input_screening_ms` | `number` or `null` | Total screening duration |
+
+When the action is `redact`, the audit log `query` field stores the **original** query. The sanitised version is what was forwarded to the LLM. Both are recorded. Compliance teams need to know what was actually said.
+
+## Configuration
+
+Guardrails are configured per workspace. A workspace can have:
+- No guardrails (default, behaves like today)
+- Pattern-only (fast, no external dependencies)
+- Pattern + LLM (defense in depth)
+- Pattern + LLM + marketplace plugins (full chain)
+
+Configuration is stored in workspace settings and managed via the dashboard UI or API.

--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -1,115 +1,113 @@
 # Guardrails
 
-Guardrails are the screening layer that sits between consumers and the LLM. They intercept queries and responses to detect, redact, or block sensitive content before it leaves your infrastructure.
+Guardrails are middleware for AI queries. They sit in the pipeline between the consumer and the LLM, and each one can inspect, modify, replace, or block the query before it moves to the next stage.
 
-## Pipeline stages
+## The middleware model
 
-Guardrails run at two points in the conversation flow:
-
-| Stage | When | What it screens | Example |
-|---|---|---|---|
-| `pre-llm` | After user sends query, before LLM receives it | User input | PII, credentials, IP, confidential data |
-| `post-llm` | After LLM responds, before user receives it | Model output | Hallucinations, toxic content, brand violations |
-
-Each stage supports multiple guardrails chained in sequence. The first `block` stops the chain. Redactions accumulate through the chain.
-
-## Actions
-
-| Action | What happens |
-|---|---|
-| `pass` | No issue detected. Content forwarded unchanged. |
-| `redact` | Sensitive tokens replaced with `[REDACTED:category]`. Sanitised version forwarded. |
-| `block` | Content rejected. User receives an explanation. Nothing forwarded. |
-
-## Built-in guardrails (open source)
-
-### PatternInputGuardrail
-
-Regex and token matching. No model required, no data egress. Covers:
-- South African ID numbers
-- Credit card numbers (Luhn-validated)
-- Email addresses
-- Phone numbers
-- Custom regex patterns per workspace
-
-### LlmInputGuardrail
-
-Calls any OpenAI-compatible endpoint to classify the query. Self-hosters point this at Ollama, a private Azure deployment, or any locally-hosted model. The screening happens privately before the query reaches the public LLM.
-
-## Marketplace guardrails
-
-Third-party guardrails install via the marketplace. They register as pipeline plugins with a `pre-llm` or `post-llm` stage and run as part of the guardrail chain.
-
-Example marketplace plugins:
-- **Redact** (by Numstack) - Advanced PII detection with ML-based entity recognition
-- **Safety** (by Numstack) - Output validation for hallucinations, toxicity, brand voice
-
-## Events
-
-Every guardrail screening emits events that marketplace products can subscribe to via hooks:
-
-| Event | When | Payload |
-|---|---|---|
-| `guardrail.triggered` | Any non-pass result | source, action, categories, confidence |
-| `guardrail.blocked` | Query blocked | source, categories, message |
-| `guardrail.redacted` | Content redacted | source, categories, redacted fields |
-
-### Why events matter
-
-Events connect guardrails to the broader product ecosystem:
-
-- **Sherlock** subscribes to `guardrail.triggered` - blocked queries are a fraud signal (user may be attempting data exfiltration)
-- **Abide** subscribes to `guardrail.blocked` - a blocked query could indicate a policy violation worth logging for compliance
-- **Audit** subscribes to all guardrail events - every screening decision is part of the immutable compliance trail
-
-## Guardrail chain execution
+Each guardrail is a filter. It receives the query in its current state, does whatever it needs to do, and passes its version forward. Like Express middleware for HTTP requests, but for AI conversations.
 
 ```
 User query
-  │
-  ▼
-┌─────────────────────┐
-│ PatternInputGuardrail│ ── regex/token matching (fast, no external calls)
-└──────────┬──────────┘
-           │ pass or redacted query
-           ▼
-┌─────────────────────┐
-│ LlmInputGuardrail   │ ── calls private model endpoint (deeper analysis)
-└──────────┬──────────┘
-           │ pass or redacted query
-           ▼
-┌─────────────────────┐
-│ Marketplace plugins  │ ── installed guardrails run in install order
-└──────────┬──────────┘
-           │
-           ▼
-       Forward to LLM (or block)
+  → Filter 1 (pattern matching, masks PII)
+  → Filter 2 (AI classifier, catches nuance)
+  → Filter 3 (domain-specific, industry terms)
+  → Forward to LLM (or block with explanation)
 ```
 
-1. Each guardrail receives the output of the previous one
-2. First `block` stops the entire chain
-3. Redactions accumulate through the chain
-4. Events emitted after each guardrail completes
-5. All results logged to audit trail (original query preserved)
+Each filter receives:
+- `query` - the current state (may be modified by previous filters)
+- `original` - the unmodified input (always preserved for audit)
+- `context` - workspace, user, consumer type
+- `metadata` - accumulated by previous filters
+
+Each filter returns:
+- `action: 'continue'` - pass to next filter (optionally with modified query)
+- `action: 'block'` - stop the chain, return reason to user
+
+## Pipeline stages
+
+| Stage | When | Example filters |
+|---|---|---|
+| `pre-llm` | Before the query reaches the LLM | PII masking, credential blocking, content classification |
+| `post-llm` | Before the response reaches the user | Hallucination detection, toxic content filtering, brand voice |
+
+## Pattern actions
+
+The built-in PatternGuardrail supports four actions per rule:
+
+| Action | What it does | Example |
+|---|---|---|
+| `mask` | Replace matched content with a placeholder | `john@example.com` → `[PII]` |
+| `hash` | Replace with a consistent hash (same input = same output) | `john@example.com` → `[hash:a1b2c3d4]` |
+| `remove` | Strip the matched content entirely | `john@example.com` → `` |
+| `block` | Stop the query from proceeding | Credit card numbers, private keys |
+
+Custom replacements can be specified per rule.
+
+## Built-in guardrails
+
+### PatternGuardrail
+
+Regex and token matching. No model required, no data egress. Built-in rules cover:
+- South African ID numbers (mask)
+- Credit card numbers (block)
+- Email addresses (hash)
+- Phone numbers (mask)
+- API keys, AWS keys, private keys (block)
+
+Custom rules can be added per workspace.
+
+### LlmGuardrail
+
+Calls any OpenAI-compatible endpoint to analyse the query. The AI can suggest modifications (find/replace pairs) or block entirely. Point it at Ollama, a private Azure deployment, or any locally-hosted model.
+
+## Marketplace guardrails
+
+Third-party guardrails install via the marketplace. They implement the same `GuardrailPlugin` interface and join the chain as additional filters.
+
+## Events
+
+Every query that passes through the guardrail pipeline emits events:
+
+| Event | When |
+|---|---|
+| `guardrail.processed` | Every query that goes through the chain |
+| `guardrail.modified` | Query was modified by one or more filters |
+| `guardrail.blocked` | Query was blocked |
 
 ## Audit logging
 
-When a query is screened, three fields are added to the audit log:
+When a query is processed, three fields are written to the audit log:
 
-| Field | Type | Description |
-|---|---|---|
-| `input_screening_action` | `pass`, `redact`, `block`, or `null` | Final action taken |
-| `input_screening_categories` | `string[]` or `null` | All detected categories across the chain |
-| `input_screening_ms` | `number` or `null` | Total screening duration |
+| Field | Description |
+|---|---|
+| `input_screening_action` | `modified`, `block`, or `null` (no guardrails) |
+| `input_screening_categories` | Annotations from all filters in the chain |
+| `input_screening_ms` | Total pipeline duration |
 
-When the action is `redact`, the audit log `query` field stores the **original** query. The sanitised version is what was forwarded to the LLM. Both are recorded. Compliance teams need to know what was actually said.
+The audit log `query` field stores the **original** query. The modified version is what was forwarded to the LLM. Both are recorded.
+
+## Best practices
+
+### Keep filters focused
+Each filter should do one thing. A PII filter should not also check for credentials. Separate concerns make the chain easier to debug and maintain.
+
+### Order matters
+Fast, cheap filters first (pattern matching). Slow, expensive filters last (LLM classification). This minimises latency for clean queries.
+
+### Fail open by default
+If a filter errors, it should return `continue` (not block). A failed guardrail should not silently prevent all queries. Log the error and let the query through.
+
+### Domain experts own their filters
+A fintech compliance team maintains the trading terminology filter. A healthcare organisation maintains the HIPAA filter. The platform provides the pipeline. The domain experts provide the intelligence.
+
+### Cache where possible
+Guardrail decisions for identical queries should be cacheable. For AI-based filters, consider semantic caching where similar (not just identical) queries can reuse previous decisions.
 
 ## Configuration
 
 Guardrails are configured per workspace. A workspace can have:
 - No guardrails (default, behaves like today)
 - Pattern-only (fast, no external dependencies)
-- Pattern + LLM (defense in depth)
+- Pattern + LLM (defence in depth)
 - Pattern + LLM + marketplace plugins (full chain)
-
-Configuration is stored in workspace settings and managed via the dashboard UI or API.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@modelcontextprotocol/sdk": "^1.12.0",
     "@slack/bolt": "^4.2.0",
     "@supaproxy/consumers": "0.1.0",
+    "@supaproxy/guardrails": "^0.1.0",
     "@supaproxy/providers": "0.1.0",
     "bcrypt": "^6.0.0",
     "bullmq": "^5.74.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@modelcontextprotocol/sdk": "^1.12.0",
     "@slack/bolt": "^4.2.0",
     "@supaproxy/consumers": "0.1.0",
-    "@supaproxy/guardrails": "^0.1.0",
+    "@supaproxy/guardrails": "^0.2.0",
     "@supaproxy/providers": "0.1.0",
     "bcrypt": "^6.0.0",
     "bullmq": "^5.74.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ dependencies:
   '@supaproxy/consumers':
     specifier: 0.1.0
     version: 0.1.0(@slack/bolt@4.7.0)
+  '@supaproxy/guardrails':
+    specifier: ^0.1.0
+    version: 0.1.0
   '@supaproxy/providers':
     specifier: 0.1.0
     version: 0.1.0(@anthropic-ai/sdk@0.90.0)(openai@6.35.0)
@@ -882,6 +885,10 @@ packages:
     dependencies:
       '@slack/bolt': 4.7.0(@types/express@5.0.6)
       pino: 9.14.0
+    dev: false
+
+  /@supaproxy/guardrails@0.1.0:
+    resolution: {integrity: sha512-mmGA8iwnd5Hn0AGi1vIYwHjhMDVjwqIMHUsOqMq3HudTpkIPeVYugXYtijWnMB4Xh7TI+JTud/MXipfbApTCUQ==}
     dev: false
 
   /@supaproxy/providers@0.1.0(@anthropic-ai/sdk@0.90.0)(openai@6.35.0):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ dependencies:
     specifier: 0.1.0
     version: 0.1.0(@slack/bolt@4.7.0)
   '@supaproxy/guardrails':
-    specifier: ^0.1.0
-    version: 0.1.0
+    specifier: ^0.2.0
+    version: 0.2.0
   '@supaproxy/providers':
     specifier: 0.1.0
     version: 0.1.0(@anthropic-ai/sdk@0.90.0)(openai@6.35.0)
@@ -887,8 +887,8 @@ packages:
       pino: 9.14.0
     dev: false
 
-  /@supaproxy/guardrails@0.1.0:
-    resolution: {integrity: sha512-mmGA8iwnd5Hn0AGi1vIYwHjhMDVjwqIMHUsOqMq3HudTpkIPeVYugXYtijWnMB4Xh7TI+JTud/MXipfbApTCUQ==}
+  /@supaproxy/guardrails@0.2.0:
+    resolution: {integrity: sha512-aBg0+TPBj5U+WR22DonMnC5k2nUocswgiTkdhP/cZnppAPZo8J8YWyqm13kGEgFw3lF+cNkFe2pM4QXbzBFxUA==}
     dev: false
 
   /@supaproxy/providers@0.1.0(@anthropic-ai/sdk@0.90.0)(openai@6.35.0):

--- a/src/application/ports/InputGuardrail.ts
+++ b/src/application/ports/InputGuardrail.ts
@@ -1,25 +1,22 @@
 /**
- * Input Guardrail port — re-exports from @supaproxy/guardrails.
+ * Input Guardrail port - re-exports from @supaproxy/guardrails.
  *
- * The GuardrailPlugin interface from the package IS the port.
- * This file provides the chain runner and type aliases.
+ * Each plugin is middleware that can modify, replace, or block a query.
+ * The chain runner pipes the output of one filter into the next.
  *
- * Pipeline stages:
- *   pre-llm  — input screening (before LLM receives the query)
- *   post-llm — output validation (before user receives the response)
- *
- * Events emitted by the server after screening:
- *   guardrail.triggered — any non-pass result
- *   guardrail.blocked   — query blocked
- *   guardrail.redacted  — content redacted
+ * Events emitted by the server after processing:
+ *   guardrail.processed - every query that passes through the chain
+ *   guardrail.modified  - query was modified by one or more filters
+ *   guardrail.blocked   - query was blocked
  */
 export type {
   GuardrailPlugin as InputGuardrail,
-  GuardrailAction,
+  GuardrailInput,
+  GuardrailOutput,
   GuardrailStage,
   GuardrailContext,
-  ScreeningResult,
   PatternRule,
+  PatternAction,
 } from '@supaproxy/guardrails'
 
 export { runGuardrailChain } from './guardrailChain.js'

--- a/src/application/ports/InputGuardrail.ts
+++ b/src/application/ports/InputGuardrail.ts
@@ -1,0 +1,25 @@
+/**
+ * Input Guardrail port — re-exports from @supaproxy/guardrails.
+ *
+ * The GuardrailPlugin interface from the package IS the port.
+ * This file provides the chain runner and type aliases.
+ *
+ * Pipeline stages:
+ *   pre-llm  — input screening (before LLM receives the query)
+ *   post-llm — output validation (before user receives the response)
+ *
+ * Events emitted by the server after screening:
+ *   guardrail.triggered — any non-pass result
+ *   guardrail.blocked   — query blocked
+ *   guardrail.redacted  — content redacted
+ */
+export type {
+  GuardrailPlugin as InputGuardrail,
+  GuardrailAction,
+  GuardrailStage,
+  GuardrailContext,
+  ScreeningResult,
+  PatternRule,
+} from '@supaproxy/guardrails'
+
+export { runGuardrailChain } from './guardrailChain.js'

--- a/src/application/ports/guardrailChain.test.ts
+++ b/src/application/ports/guardrailChain.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { runGuardrailChain } from './guardrailChain.js'
+import { PatternGuardrail } from '@supaproxy/guardrails'
+import type { GuardrailPlugin, ScreeningResult, GuardrailContext } from '@supaproxy/guardrails'
+
+const ctx: GuardrailContext = { workspaceId: 'ws-1' }
+
+describe('runGuardrailChain', () => {
+  it('passes clean queries through unchanged', async () => {
+    const guardrail = new PatternGuardrail()
+    const result = await runGuardrailChain([guardrail], 'What is the weather today?', ctx)
+
+    expect(result.finalAction).toBe('pass')
+    expect(result.sanitisedQuery).toBe('What is the weather today?')
+    expect(result.results).toHaveLength(1)
+  })
+
+  it('redacts email addresses', async () => {
+    const guardrail = new PatternGuardrail()
+    const result = await runGuardrailChain([guardrail], 'Send an email to john@example.com about the project', ctx)
+
+    expect(result.finalAction).toBe('redact')
+    expect(result.sanitisedQuery).toContain('[REDACTED:pii]')
+    expect(result.sanitisedQuery).not.toContain('john@example.com')
+  })
+
+  it('blocks credit card numbers', async () => {
+    const guardrail = new PatternGuardrail()
+    const result = await runGuardrailChain([guardrail], 'My card number is 4111111111111111', ctx)
+
+    expect(result.finalAction).toBe('block')
+    expect(result.results[0].detectedCategories).toContain('pii')
+  })
+
+  it('blocks AWS access keys', async () => {
+    const guardrail = new PatternGuardrail()
+    const result = await runGuardrailChain([guardrail], 'Use this key AKIAIOSFODNN7EXAMPLE to access S3', ctx)
+
+    expect(result.finalAction).toBe('block')
+    expect(result.results[0].detectedCategories).toContain('credentials')
+  })
+
+  it('chains multiple guardrails - redactions accumulate', async () => {
+    const first = new PatternGuardrail()
+    const second: GuardrailPlugin = {
+      id: 'custom',
+      name: 'Custom',
+      description: 'test',
+      stage: 'pre-llm',
+      async screen(query: string): Promise<ScreeningResult> {
+        return { action: 'pass', source: 'custom', detectedCategories: [], confidence: 1, durationMs: 0 }
+      },
+    }
+
+    const result = await runGuardrailChain([first, second], 'Contact john@example.com', ctx)
+
+    expect(result.finalAction).toBe('redact')
+    expect(result.results).toHaveLength(2)
+    expect(result.results[0].action).toBe('redact')
+    expect(result.results[1].action).toBe('pass')
+  })
+
+  it('first block stops the chain', async () => {
+    const blocker: GuardrailPlugin = {
+      id: 'blocker',
+      name: 'Blocker',
+      description: 'test',
+      stage: 'pre-llm',
+      async screen(): Promise<ScreeningResult> {
+        return { action: 'block', source: 'blocker', detectedCategories: ['test'], confidence: 1, message: 'Blocked', durationMs: 0 }
+      },
+    }
+    const neverReached: GuardrailPlugin = {
+      id: 'never',
+      name: 'Never',
+      description: 'test',
+      stage: 'pre-llm',
+      async screen(): Promise<ScreeningResult> {
+        throw new Error('Should not be called')
+      },
+    }
+
+    const result = await runGuardrailChain([blocker, neverReached], 'test query', ctx)
+
+    expect(result.finalAction).toBe('block')
+    expect(result.results).toHaveLength(1)
+  })
+
+  it('empty guardrail list passes everything', async () => {
+    const result = await runGuardrailChain([], 'anything goes', ctx)
+
+    expect(result.finalAction).toBe('pass')
+    expect(result.sanitisedQuery).toBe('anything goes')
+  })
+})

--- a/src/application/ports/guardrailChain.test.ts
+++ b/src/application/ports/guardrailChain.test.ts
@@ -1,63 +1,63 @@
 import { describe, it, expect } from 'vitest'
 import { runGuardrailChain } from './guardrailChain.js'
 import { PatternGuardrail } from '@supaproxy/guardrails'
-import type { GuardrailPlugin, ScreeningResult, GuardrailContext } from '@supaproxy/guardrails'
+import type { GuardrailPlugin, GuardrailInput, GuardrailOutput } from '@supaproxy/guardrails'
 
-const ctx: GuardrailContext = { workspaceId: 'ws-1' }
+const ctx = { workspaceId: 'ws-1' }
 
 describe('runGuardrailChain', () => {
   it('passes clean queries through unchanged', async () => {
     const guardrail = new PatternGuardrail()
     const result = await runGuardrailChain([guardrail], 'What is the weather today?', ctx)
 
-    expect(result.finalAction).toBe('pass')
-    expect(result.sanitisedQuery).toBe('What is the weather today?')
-    expect(result.results).toHaveLength(1)
+    expect(result.blocked).toBe(false)
+    expect(result.query).toBe('What is the weather today?')
+    expect(result.original).toBe('What is the weather today?')
   })
 
-  it('redacts email addresses', async () => {
+  it('masks email addresses with hash', async () => {
     const guardrail = new PatternGuardrail()
-    const result = await runGuardrailChain([guardrail], 'Send an email to john@example.com about the project', ctx)
+    const result = await runGuardrailChain([guardrail], 'Send email to john@example.com about project', ctx)
 
-    expect(result.finalAction).toBe('redact')
-    expect(result.sanitisedQuery).toContain('[REDACTED:pii]')
-    expect(result.sanitisedQuery).not.toContain('john@example.com')
+    expect(result.blocked).toBe(false)
+    expect(result.query).not.toContain('john@example.com')
+    expect(result.query).toContain('[hash:')
+    expect(result.original).toContain('john@example.com')
   })
 
   it('blocks credit card numbers', async () => {
     const guardrail = new PatternGuardrail()
     const result = await runGuardrailChain([guardrail], 'My card number is 4111111111111111', ctx)
 
-    expect(result.finalAction).toBe('block')
-    expect(result.results[0].detectedCategories).toContain('pii')
+    expect(result.blocked).toBe(true)
+    expect(result.reason).toBeDefined()
+    expect(result.annotations.some(a => a.includes('blocked'))).toBe(true)
   })
 
   it('blocks AWS access keys', async () => {
     const guardrail = new PatternGuardrail()
-    const result = await runGuardrailChain([guardrail], 'Use this key AKIAIOSFODNN7EXAMPLE to access S3', ctx)
+    const result = await runGuardrailChain([guardrail], 'Use this key AKIAIOSFODNN7EXAMPLE', ctx)
 
-    expect(result.finalAction).toBe('block')
-    expect(result.results[0].detectedCategories).toContain('credentials')
+    expect(result.blocked).toBe(true)
   })
 
-  it('chains multiple guardrails - redactions accumulate', async () => {
+  it('chains multiple filters, modifications accumulate', async () => {
     const first = new PatternGuardrail()
-    const second: GuardrailPlugin = {
-      id: 'custom',
-      name: 'Custom',
+    const uppercaser: GuardrailPlugin = {
+      id: 'upper',
+      name: 'Upper',
       description: 'test',
       stage: 'pre-llm',
-      async screen(query: string): Promise<ScreeningResult> {
-        return { action: 'pass', source: 'custom', detectedCategories: [], confidence: 1, durationMs: 0 }
+      async process(input: GuardrailInput): Promise<GuardrailOutput> {
+        return { action: 'continue', query: input.query.toUpperCase(), annotations: ['uppercased'] }
       },
     }
 
-    const result = await runGuardrailChain([first, second], 'Contact john@example.com', ctx)
+    const result = await runGuardrailChain([first, uppercaser], 'hello world', ctx)
 
-    expect(result.finalAction).toBe('redact')
-    expect(result.results).toHaveLength(2)
-    expect(result.results[0].action).toBe('redact')
-    expect(result.results[1].action).toBe('pass')
+    expect(result.blocked).toBe(false)
+    expect(result.query).toBe('HELLO WORLD')
+    expect(result.annotations).toContain('uppercased')
   })
 
   it('first block stops the chain', async () => {
@@ -66,8 +66,8 @@ describe('runGuardrailChain', () => {
       name: 'Blocker',
       description: 'test',
       stage: 'pre-llm',
-      async screen(): Promise<ScreeningResult> {
-        return { action: 'block', source: 'blocker', detectedCategories: ['test'], confidence: 1, message: 'Blocked', durationMs: 0 }
+      async process(): Promise<GuardrailOutput> {
+        return { action: 'block', reason: 'Blocked by test', annotations: ['test-blocked'] }
       },
     }
     const neverReached: GuardrailPlugin = {
@@ -75,21 +75,55 @@ describe('runGuardrailChain', () => {
       name: 'Never',
       description: 'test',
       stage: 'pre-llm',
-      async screen(): Promise<ScreeningResult> {
+      async process(): Promise<GuardrailOutput> {
         throw new Error('Should not be called')
       },
     }
 
     const result = await runGuardrailChain([blocker, neverReached], 'test query', ctx)
 
-    expect(result.finalAction).toBe('block')
-    expect(result.results).toHaveLength(1)
+    expect(result.blocked).toBe(true)
+    expect(result.reason).toBe('Blocked by test')
   })
 
-  it('empty guardrail list passes everything', async () => {
+  it('empty chain passes everything', async () => {
     const result = await runGuardrailChain([], 'anything goes', ctx)
 
-    expect(result.finalAction).toBe('pass')
-    expect(result.sanitisedQuery).toBe('anything goes')
+    expect(result.blocked).toBe(false)
+    expect(result.query).toBe('anything goes')
+  })
+
+  it('metadata accumulates through the chain', async () => {
+    const filter1: GuardrailPlugin = {
+      id: 'f1', name: 'F1', description: 'test', stage: 'pre-llm',
+      async process(): Promise<GuardrailOutput> {
+        return { action: 'continue', metadata: { scanned: true } }
+      },
+    }
+    const filter2: GuardrailPlugin = {
+      id: 'f2', name: 'F2', description: 'test', stage: 'pre-llm',
+      async process(input: GuardrailInput): Promise<GuardrailOutput> {
+        return { action: 'continue', metadata: { previousScanned: input.metadata.scanned } }
+      },
+    }
+
+    const result = await runGuardrailChain([filter1, filter2], 'test', ctx)
+
+    expect(result.metadata.scanned).toBe(true)
+    expect(result.metadata.previousScanned).toBe(true)
+  })
+
+  it('original query is always preserved', async () => {
+    const replacer: GuardrailPlugin = {
+      id: 'replacer', name: 'Replacer', description: 'test', stage: 'pre-llm',
+      async process(): Promise<GuardrailOutput> {
+        return { action: 'continue', query: 'completely different query' }
+      },
+    }
+
+    const result = await runGuardrailChain([replacer], 'original sensitive query', ctx)
+
+    expect(result.query).toBe('completely different query')
+    expect(result.original).toBe('original sensitive query')
   })
 })

--- a/src/application/ports/guardrailChain.ts
+++ b/src/application/ports/guardrailChain.ts
@@ -1,34 +1,69 @@
-import type { GuardrailPlugin, GuardrailAction, GuardrailContext, ScreeningResult } from '@supaproxy/guardrails'
+import type { GuardrailPlugin, GuardrailContext, GuardrailOutput } from '@supaproxy/guardrails'
+
+export interface ChainResult {
+  blocked: boolean
+  query: string
+  original: string
+  reason?: string
+  annotations: string[]
+  metadata: Record<string, unknown>
+  filterCount: number
+}
 
 /**
- * Runs multiple guardrails in sequence.
- * First 'block' stops the chain. Redactions accumulate.
+ * Runs multiple guardrails in sequence as middleware.
+ * Each filter receives the output of the previous one.
+ * First 'block' stops the chain.
+ * Modifications accumulate through the pipeline.
  */
 export async function runGuardrailChain(
   guardrails: GuardrailPlugin[],
   query: string,
   context: GuardrailContext,
-): Promise<{ finalAction: GuardrailAction; results: ScreeningResult[]; sanitisedQuery: string }> {
-  const results: ScreeningResult[] = []
+): Promise<ChainResult> {
   let currentQuery = query
+  const allAnnotations: string[] = []
+  let metadata: Record<string, unknown> = {}
 
   for (const guardrail of guardrails) {
-    const result = await guardrail.screen(currentQuery, context)
-    results.push(result)
+    const output: GuardrailOutput = await guardrail.process({
+      query: currentQuery,
+      original: query,
+      context,
+      metadata,
+    })
 
-    if (result.action === 'block') {
-      return { finalAction: 'block', results, sanitisedQuery: currentQuery }
+    if (output.annotations) {
+      allAnnotations.push(...output.annotations)
     }
 
-    if (result.action === 'redact' && result.sanitisedQuery) {
-      currentQuery = result.sanitisedQuery
+    if (output.metadata) {
+      metadata = { ...metadata, ...output.metadata }
+    }
+
+    if (output.action === 'block') {
+      return {
+        blocked: true,
+        query: currentQuery,
+        original: query,
+        reason: output.reason,
+        annotations: allAnnotations,
+        metadata,
+        filterCount: guardrails.length,
+      }
+    }
+
+    if (output.query) {
+      currentQuery = output.query
     }
   }
 
-  const wasRedacted = results.some(r => r.action === 'redact')
   return {
-    finalAction: wasRedacted ? 'redact' : 'pass',
-    results,
-    sanitisedQuery: currentQuery,
+    blocked: false,
+    query: currentQuery,
+    original: query,
+    annotations: allAnnotations,
+    metadata,
+    filterCount: guardrails.length,
   }
 }

--- a/src/application/ports/guardrailChain.ts
+++ b/src/application/ports/guardrailChain.ts
@@ -1,0 +1,34 @@
+import type { GuardrailPlugin, GuardrailAction, GuardrailContext, ScreeningResult } from '@supaproxy/guardrails'
+
+/**
+ * Runs multiple guardrails in sequence.
+ * First 'block' stops the chain. Redactions accumulate.
+ */
+export async function runGuardrailChain(
+  guardrails: GuardrailPlugin[],
+  query: string,
+  context: GuardrailContext,
+): Promise<{ finalAction: GuardrailAction; results: ScreeningResult[]; sanitisedQuery: string }> {
+  const results: ScreeningResult[] = []
+  let currentQuery = query
+
+  for (const guardrail of guardrails) {
+    const result = await guardrail.screen(currentQuery, context)
+    results.push(result)
+
+    if (result.action === 'block') {
+      return { finalAction: 'block', results, sanitisedQuery: currentQuery }
+    }
+
+    if (result.action === 'redact' && result.sanitisedQuery) {
+      currentQuery = result.sanitisedQuery
+    }
+  }
+
+  const wasRedacted = results.some(r => r.action === 'redact')
+  return {
+    finalAction: wasRedacted ? 'redact' : 'pass',
+    results,
+    sanitisedQuery: currentQuery,
+  }
+}

--- a/src/application/query/ExecuteQueryUseCase.ts
+++ b/src/application/query/ExecuteQueryUseCase.ts
@@ -3,8 +3,10 @@ import type { OrganisationRepository } from '../../domain/organisation/repositor
 import type { AuditLogRepository, AuditLogData } from '../../domain/audit/repository.js'
 import type { AIToolSpec, AIMessage, AIContentBlock, ProviderPlugin } from '@supaproxy/providers'
 import type { registry as ProviderRegistryType } from '@supaproxy/providers'
+import type { GuardrailPlugin } from '@supaproxy/guardrails'
 import type { McpClientFactory, McpConnection } from '../ports/McpClient.js'
 import type { ManageConversationUseCase } from '../conversation/ManageConversationUseCase.js'
+import { runGuardrailChain } from '../ports/guardrailChain.js'
 import { generateId } from '../../domain/shared/EntityId.js'
 import { NotFoundError, ConfigurationError } from '../../domain/shared/errors.js'
 import pino from 'pino'
@@ -64,6 +66,7 @@ export class ExecuteQueryUseCase {
     private readonly providerRegistry: typeof ProviderRegistryType,
     private readonly mcpFactory: McpClientFactory,
     private readonly conversationUseCase: ManageConversationUseCase,
+    private readonly guardrails: GuardrailPlugin[] = [],
   ) {}
 
   async execute(workspaceId: string, query: string, meta: QueryMeta): Promise<QueryResult> {
@@ -94,6 +97,45 @@ export class ExecuteQueryUseCase {
       })
     }
 
+    // ── Input guardrail screening ──
+    let screeningAction: string | null = null
+    let screeningCategories: string[] | null = null
+    let screeningMs: number | null = null
+    let queryToForward = query
+
+    if (this.guardrails.length > 0) {
+      const screening = await runGuardrailChain(this.guardrails, query, {
+        workspaceId,
+        userId: meta.userId,
+        consumerType: meta.consumerType,
+      })
+
+      screeningAction = screening.finalAction
+      screeningCategories = screening.results.flatMap(r => r.detectedCategories)
+      screeningMs = screening.results.reduce((sum, r) => sum + r.durationMs, 0)
+
+      if (screening.finalAction === 'block') {
+        const blockResult = screening.results.find(r => r.action === 'block')
+        log.info({ workspace: workspaceId, categories: screeningCategories, source: blockResult?.source }, 'Query blocked by guardrail')
+
+        const auditLogId = generateId()
+        await this.writeAuditLog(auditLogId, workspaceId, conversationId, query, this.buildInternalResult({ error: 'input_blocked', durationMs: Date.now() - startTime }), meta, { screeningAction, screeningCategories, screeningMs })
+
+        return this.buildResult({
+          answer: blockResult?.message || 'This query was blocked by your organisation\'s input policy.',
+          error: 'input_blocked',
+          durationMs: Date.now() - startTime,
+          conversationId,
+          sessionId,
+        })
+      }
+
+      if (screening.finalAction === 'redact') {
+        queryToForward = screening.sanitisedQuery
+        log.info({ workspace: workspaceId, categories: screeningCategories }, 'Query redacted by guardrail')
+      }
+    }
+
     const connections = await this.workspaceRepo.findConnectionConfigs(workspaceId)
     const { tools, mcpConnections } = await this.discoverTools(connections, workspaceId)
 
@@ -111,7 +153,7 @@ export class ExecuteQueryUseCase {
         throw new Error('No AI model configured for this workspace. Set a model in workspace settings.')
       }
 
-      const result = await this.runAgentLoop(query, provider, {
+      const result = await this.runAgentLoop(queryToForward, provider, {
         model: workspace.model,
         systemPrompt: workspace.system_prompt || 'You are a helpful assistant.',
         maxToolRounds: workspace.max_tool_rounds || 10,
@@ -124,8 +166,8 @@ export class ExecuteQueryUseCase {
       // Cost is accumulated per-round from the provider's usage.cost_usd
 
       const auditLogId = generateId()
-      await this.writeAuditLog(auditLogId, workspaceId, conversationId, query, result, meta)
-      await this.recordMessages(conversationId, query, result.answer, auditLogId)
+      await this.writeAuditLog(auditLogId, workspaceId, conversationId, query, result, meta, { screeningAction, screeningCategories, screeningMs })
+      await this.recordMessages(conversationId, queryToForward, result.answer, auditLogId)
 
       log.info({
         workspace: workspaceId,
@@ -281,6 +323,10 @@ export class ExecuteQueryUseCase {
     return result
   }
 
+  private buildInternalResult(overrides: Partial<{ toolsCalled: ToolCallRecord[]; connectionsHit: string[]; tokensInput: number; tokensOutput: number; costUsd: number; durationMs: number; error: string | null }> = {}) {
+    return { toolsCalled: [] as ToolCallRecord[], connectionsHit: [] as string[], tokensInput: 0, tokensOutput: 0, costUsd: 0, durationMs: 0, error: null as string | null, ...overrides }
+  }
+
   private async writeAuditLog(
     auditLogId: string,
     workspaceId: string,
@@ -288,6 +334,7 @@ export class ExecuteQueryUseCase {
     query: string,
     result: { toolsCalled: ToolCallRecord[]; connectionsHit: string[]; tokensInput: number; tokensOutput: number; costUsd: number; durationMs: number; error: string | null },
     meta: QueryMeta,
+    screening?: { screeningAction: string | null; screeningCategories: string[] | null; screeningMs: number | null },
   ): Promise<void> {
     try {
       const data: AuditLogData = {
@@ -306,6 +353,9 @@ export class ExecuteQueryUseCase {
         cost_usd: result.costUsd,
         duration_ms: result.durationMs,
         error: result.error,
+        input_screening_action: screening?.screeningAction || null,
+        input_screening_categories: screening?.screeningCategories ? JSON.stringify(screening.screeningCategories) : null,
+        input_screening_ms: screening?.screeningMs || null,
       }
       await this.auditRepo.create(data)
     } catch (err) {

--- a/src/application/query/ExecuteQueryUseCase.ts
+++ b/src/application/query/ExecuteQueryUseCase.ts
@@ -97,32 +97,31 @@ export class ExecuteQueryUseCase {
       })
     }
 
-    // ── Input guardrail screening ──
+    // ── Input guardrail pipeline ──
     let screeningAction: string | null = null
     let screeningCategories: string[] | null = null
     let screeningMs: number | null = null
     let queryToForward = query
 
     if (this.guardrails.length > 0) {
-      const screening = await runGuardrailChain(this.guardrails, query, {
+      const screenStart = Date.now()
+      const chain = await runGuardrailChain(this.guardrails, query, {
         workspaceId,
         userId: meta.userId,
         consumerType: meta.consumerType,
       })
+      screeningMs = Date.now() - screenStart
+      screeningCategories = chain.annotations.length > 0 ? chain.annotations : null
 
-      screeningAction = screening.finalAction
-      screeningCategories = screening.results.flatMap(r => r.detectedCategories)
-      screeningMs = screening.results.reduce((sum, r) => sum + r.durationMs, 0)
-
-      if (screening.finalAction === 'block') {
-        const blockResult = screening.results.find(r => r.action === 'block')
-        log.info({ workspace: workspaceId, categories: screeningCategories, source: blockResult?.source }, 'Query blocked by guardrail')
+      if (chain.blocked) {
+        screeningAction = 'block'
+        log.info({ workspace: workspaceId, annotations: chain.annotations }, 'Query blocked by guardrail')
 
         const auditLogId = generateId()
         await this.writeAuditLog(auditLogId, workspaceId, conversationId, query, this.buildInternalResult({ error: 'input_blocked', durationMs: Date.now() - startTime }), meta, { screeningAction, screeningCategories, screeningMs })
 
         return this.buildResult({
-          answer: blockResult?.message || 'This query was blocked by your organisation\'s input policy.',
+          answer: chain.reason || 'This query was blocked by your organisation\'s input policy.',
           error: 'input_blocked',
           durationMs: Date.now() - startTime,
           conversationId,
@@ -130,9 +129,10 @@ export class ExecuteQueryUseCase {
         })
       }
 
-      if (screening.finalAction === 'redact') {
-        queryToForward = screening.sanitisedQuery
-        log.info({ workspace: workspaceId, categories: screeningCategories }, 'Query redacted by guardrail')
+      if (chain.query !== query) {
+        screeningAction = 'modified'
+        queryToForward = chain.query
+        log.info({ workspace: workspaceId, annotations: chain.annotations }, 'Query modified by guardrail')
       }
     }
 

--- a/src/container.ts
+++ b/src/container.ts
@@ -10,6 +10,7 @@ import { MysqlModelRepository } from './infrastructure/persistence/mysql/MysqlMo
 import { BcryptPasswordService } from './infrastructure/auth/BcryptPasswordService.js'
 import { JwtTokenService } from './infrastructure/auth/JwtTokenService.js'
 import { registry as providerRegistry } from '@supaproxy/providers'
+import { registry as guardrailRegistry } from '@supaproxy/guardrails'
 import { McpClientFactoryImpl } from './infrastructure/mcp/McpClientFactoryImpl.js'
 import { BullMqService } from './infrastructure/queue/BullMqService.js'
 import { SlackIntegrationTester } from './infrastructure/auth/SlackIntegrationTester.js'
@@ -184,7 +185,11 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
   }
   const connectConsumerUseCase = new ConnectConsumerUseCase(workspaceRepo, consumerTypeHandlers)
 
-  const executeQueryUseCase = new ExecuteQueryUseCase(workspaceRepo, orgRepo, auditRepo, providerRegistry, mcpFactory, manageConversationUseCase)
+  // Guardrails — built-in plugins from @supaproxy/guardrails registry.
+  // Additional guardrails can be added via marketplace plugins.
+  const guardrailPlugins = guardrailRegistry.byStage('pre-llm')
+
+  const executeQueryUseCase = new ExecuteQueryUseCase(workspaceRepo, orgRepo, auditRepo, providerRegistry, mcpFactory, manageConversationUseCase, guardrailPlugins)
   const manageQueuesUseCase = new ManageQueuesUseCase(queueService)
 
   // Build routes

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -400,6 +400,18 @@ const migrations: Migration[] = [
       await pool.execute('ALTER TABLE teams ADD UNIQUE KEY unique_org_team (org_id, name)');
     },
   },
+  {
+    version: 10,
+    name: 'input screening fields on audit_logs',
+    up: async (pool) => {
+      await pool.execute(`
+        ALTER TABLE audit_logs
+        ADD COLUMN input_screening_action VARCHAR(10) NULL,
+        ADD COLUMN input_screening_categories TEXT NULL,
+        ADD COLUMN input_screening_ms INT NULL
+      `);
+    },
+  },
 ];
 
 interface SchemaMigrationRow extends mysql.RowDataPacket {

--- a/src/domain/audit/repository.ts
+++ b/src/domain/audit/repository.ts
@@ -14,6 +14,9 @@ export interface AuditLogData {
   cost_usd: number
   duration_ms: number
   error: string | null
+  input_screening_action: string | null
+  input_screening_categories: string | null
+  input_screening_ms: number | null
 }
 
 export interface AuditLogRepository {

--- a/src/infrastructure/persistence/mysql/MysqlAuditLogRepository.ts
+++ b/src/infrastructure/persistence/mysql/MysqlAuditLogRepository.ts
@@ -6,9 +6,9 @@ export class MysqlAuditLogRepository implements AuditLogRepository {
 
   async create(data: AuditLogData): Promise<void> {
     await this.pool.execute(
-      `INSERT INTO audit_logs (id, workspace_id, conversation_id, consumer_type, channel, user_id, user_name, query, tools_called, connections_hit, tokens_input, tokens_output, cost_usd, duration_ms, error)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      [data.id, data.workspace_id, data.conversation_id, data.consumer_type, data.channel, data.user_id, data.user_name, data.query, data.tools_called, data.connections_hit, data.tokens_input, data.tokens_output, data.cost_usd, data.duration_ms, data.error]
+      `INSERT INTO audit_logs (id, workspace_id, conversation_id, consumer_type, channel, user_id, user_name, query, tools_called, connections_hit, tokens_input, tokens_output, cost_usd, duration_ms, error, input_screening_action, input_screening_categories, input_screening_ms)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [data.id, data.workspace_id, data.conversation_id, data.consumer_type, data.channel, data.user_id, data.user_name, data.query, data.tools_called, data.connections_hit, data.tokens_input, data.tokens_output, data.cost_usd, data.duration_ms, data.error, data.input_screening_action, data.input_screening_categories, data.input_screening_ms]
     )
   }
 }

--- a/src/shared/entities.ts
+++ b/src/shared/entities.ts
@@ -56,6 +56,9 @@ export interface AuditLog {
   cost_usd: number;
   duration_ms: number;
   error: string | null;
+  input_screening_action: string | null;
+  input_screening_categories: string[] | null;
+  input_screening_ms: number | null;
   created_at: string;
 }
 


### PR DESCRIPTION
## Summary

- Add `InputGuardrail` port with chain runner for pre-LLM query screening
- Guardrail plugins from `@supaproxy/guardrails` npm package (pattern matching, LLM classification)
- Chain runs registered guardrails in sequence: first block stops, redactions accumulate
- Audit log extended with screening action, categories, and duration
- Migration v10 adds columns to `audit_logs` table
- Full architecture docs at `docs/guardrails.md`

## How it works

```
User query → PatternGuardrail → LlmGuardrail → Marketplace plugins → Forward to LLM
```

Each guardrail returns pass/redact/block. Blocked queries never reach the LLM. Redacted queries have sensitive tokens replaced. Original query always preserved in audit log.

## Test plan

- [x] 7 new guardrail chain tests (pass, redact, block, chain accumulation, empty chain)
- [x] All 159 existing tests pass
- [x] Manual: query with email address → redacted before LLM
- [x] Manual: query with credit card → blocked, user sees explanation
- [x] Manual: clean query → passes unchanged