### PR TITLE
feat: consumer context on queries and MCP auth headers

### DIFF
--- a/src/application/connector/SaveMcpConnectionUseCase.ts
+++ b/src/application/connector/SaveMcpConnectionUseCase.ts
@@ -10,6 +10,8 @@ interface SaveMcpInput {
   url?: string
   command?: string
   args?: string[]
+  headers?: Record<string, string>
+  env?: Record<string, string>
 }
 
 interface SaveMcpOutput {
@@ -38,8 +40,8 @@ export class SaveMcpConnectionUseCase {
     if (!exists) throw new NotFoundError('Workspace', input.workspaceId)
 
     const config = resolvedTransport === 'http'
-      ? JSON.stringify({ transport: 'http', url: input.url })
-      : JSON.stringify({ transport: 'stdio', command: input.command, args: input.args || [] })
+      ? JSON.stringify({ transport: 'http', url: input.url, ...(input.headers && Object.keys(input.headers).length > 0 ? { headers: input.headers } : {}) })
+      : JSON.stringify({ transport: 'stdio', command: input.command, args: input.args || [], ...(input.env && Object.keys(input.env).length > 0 ? { env: input.env } : {}) })
 
     const existing = await this.workspaceRepo.findConnectionByName(input.workspaceId, input.name)
 
@@ -54,15 +56,15 @@ export class SaveMcpConnectionUseCase {
     }
 
     if (resolvedTransport === 'http' && input.url) {
-      return this.discoverAndSaveTools(connId, input.url)
+      return this.discoverAndSaveTools(connId, input.url, input.headers)
     }
 
     return { status: 'saved', message: 'Connection saved. Tools will be discovered on the first query.' }
   }
 
-  private async discoverAndSaveTools(connId: string, url: string): Promise<SaveMcpOutput> {
+  private async discoverAndSaveTools(connId: string, url: string, headers?: Record<string, string>): Promise<SaveMcpOutput> {
     try {
-      const connection = await this.mcpFactory.connectHttp(url, undefined, 'supaproxy')
+      const connection = await this.mcpFactory.connectHttp(url, headers, 'supaproxy')
       try {
         if (connection.tools.length > 0) {
           await this.workspaceRepo.createTools(

--- a/src/application/connector/TestMcpConnectionUseCase.test.ts
+++ b/src/application/connector/TestMcpConnectionUseCase.test.ts
@@ -12,7 +12,7 @@ describe('TestMcpConnectionUseCase', () => {
     const uc = new TestMcpConnectionUseCase(factory)
     const result = await uc.execute('http', 'http://localhost:8080')
 
-    expect(factory.testHttp).toHaveBeenCalledWith('http://localhost:8080')
+    expect(factory.testHttp).toHaveBeenCalledWith('http://localhost:8080', undefined)
     expect(result).toEqual(testResult)
   })
 

--- a/src/application/connector/TestMcpConnectionUseCase.ts
+++ b/src/application/connector/TestMcpConnectionUseCase.ts
@@ -11,10 +11,10 @@ interface TestResult {
 export class TestMcpConnectionUseCase {
   constructor(private readonly mcpFactory: McpClientFactory) {}
 
-  async execute(transport: string, url?: string, command?: string): Promise<TestResult> {
+  async execute(transport: string, url?: string, command?: string, headers?: Record<string, string>): Promise<TestResult> {
     if (transport === 'http') {
       if (!url) return { ok: false, error: 'Server URL is required' }
-      return this.mcpFactory.testHttp(url)
+      return this.mcpFactory.testHttp(url, headers)
     }
     return { ok: false, error: 'STDIO connections are tested on first query.' }
   }

--- a/src/application/ports/McpClient.ts
+++ b/src/application/ports/McpClient.ts
@@ -18,5 +18,5 @@ export interface McpConnection {
 export interface McpClientFactory {
   connectHttp(url: string, headers?: Record<string, string>, clientName?: string): Promise<McpConnection>
   connectStdio(command: string, args: string[], env?: Record<string, string>, clientName?: string): Promise<McpConnection>
-  testHttp(url: string): Promise<{ ok: boolean; tools: number; server: string; toolNames: string[]; error?: string }>
+  testHttp(url: string, headers?: Record<string, string>): Promise<{ ok: boolean; tools: number; server: string; toolNames: string[]; error?: string }>
 }

--- a/src/infrastructure/mcp/McpClientFactoryImpl.ts
+++ b/src/infrastructure/mcp/McpClientFactoryImpl.ts
@@ -120,9 +120,9 @@ export class McpClientFactoryImpl implements McpClientFactory {
     return new StdioMcpConnection(client, transport, tools)
   }
 
-  async testHttp(url: string): Promise<{ ok: boolean; tools: number; server: string; toolNames: string[]; error?: string }> {
+  async testHttp(url: string, extraHeaders?: Record<string, string>): Promise<{ ok: boolean; tools: number; server: string; toolNames: string[]; error?: string }> {
     try {
-      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+      const headers: Record<string, string> = { 'Content-Type': 'application/json', ...extraHeaders }
       const initResult = await this.httpRequest(url, 'initialize', {
         protocolVersion: '2024-11-05',
         capabilities: {},

--- a/src/presentation/routes/connectors.ts
+++ b/src/presentation/routes/connectors.ts
@@ -15,8 +15,8 @@ const log = pino({ name: 'routes/connectors' })
 
 const slackChannelSchema = z.object({ workspace_id: z.string().min(1).max(255), channel_id: z.string().min(1).max(100), channel_name: z.string().max(255).optional() })
 const slackConnectSchema = z.object({ workspace_id: z.string().min(1).max(255), bot_token: z.string().min(1).max(500), app_token: z.string().min(1).max(500), channel_id: z.string().max(100).optional() })
-const mcpTestSchema = z.object({ transport: z.enum(['http', 'stdio']).optional(), url: z.string().url().max(2048).optional(), command: z.string().max(1000).optional() })
-const mcpSaveSchema = z.object({ workspace_id: z.string().min(1).max(255), name: z.string().min(1).max(255), transport: z.enum(['http', 'stdio']).optional(), url: z.string().url().max(2048).optional(), command: z.string().max(1000).optional(), args: z.array(z.string().max(1000)).max(50).optional() })
+const mcpTestSchema = z.object({ transport: z.enum(['http', 'stdio']).optional(), url: z.string().url().max(2048).optional(), command: z.string().max(1000).optional(), headers: z.record(z.string().max(2000)).optional() })
+const mcpSaveSchema = z.object({ workspace_id: z.string().min(1).max(255), name: z.string().min(1).max(255), transport: z.enum(['http', 'stdio']).optional(), url: z.string().url().max(2048).optional(), command: z.string().max(1000).optional(), args: z.array(z.string().max(1000)).max(50).optional(), headers: z.record(z.string().max(2000)).optional(), env: z.record(z.string().max(2000)).optional() })
 const consumerChannelSchema = z.object({ type: z.string().min(1), workspace_id: z.string().min(1).max(255), channel_id: z.string().min(1).max(100), channel_name: z.string().max(255).optional() })
 const consumerConnectSchema = z.object({ type: z.string().min(1), workspace_id: z.string().min(1).max(255), credentials: z.record(z.string().max(500)), channel_id: z.string().max(100).optional() })
 
@@ -119,7 +119,7 @@ export function createConnectorRoutes(deps: ConnectorRouteDeps) {
     const result = await parseBody(c, mcpTestSchema)
     if (!result.success) return result.response
     const transport = result.data.transport || (result.data.url ? 'http' : 'stdio')
-    const output = await deps.testMcpConnectionUseCase.execute(transport, result.data.url, result.data.command)
+    const output = await deps.testMcpConnectionUseCase.execute(transport, result.data.url, result.data.command, result.data.headers)
     return c.json(output)
   })
 
@@ -136,6 +136,8 @@ export function createConnectorRoutes(deps: ConnectorRouteDeps) {
         url: result.data.url,
         command: result.data.command,
         args: result.data.args,
+        headers: result.data.headers,
+        env: result.data.env,
       })
       return c.json(output)
     } catch (err) { return handleDomainError(c, err) }

--- a/src/presentation/routes/query.ts
+++ b/src/presentation/routes/query.ts
@@ -10,6 +10,13 @@ import { NotFoundError } from '../../domain/shared/errors.js'
 const queryBodySchema = z.object({
   query: z.string().min(1, 'Query is required').max(10000),
   session_id: z.string().max(255).optional(),
+  consumer_type: z.string().max(50).optional(),
+  consumer_context: z.object({
+    channel: z.string().max(255).optional(),
+    userId: z.string().max(255).optional(),
+    userName: z.string().max(255).optional(),
+    threadId: z.string().max(255).optional(),
+  }).optional(),
   history: z.array(z.object({
     role: z.enum(['user', 'assistant']),
     content: z.string(),
@@ -42,10 +49,12 @@ export function createQueryRoutes(deps: QueryRouteDeps) {
     await guardWorkspace(wsId, user.org_id)
 
     try {
+      const ctx = parsed.data.consumer_context
       const result = await deps.executeQueryUseCase.execute(wsId, parsed.data.query, {
-        consumerType: 'api',
-        userId: user?.id,
-        userName: user?.name,
+        consumerType: parsed.data.consumer_type || 'api',
+        channel: ctx?.channel,
+        userId: ctx?.userId || user?.id,
+        userName: ctx?.userName || user?.name,
         sessionId: parsed.data.session_id,
       })
 


### PR DESCRIPTION
Query consumer_type/context, MCP headers/env support. No breaking changes.