### PR TITLE
fix: register consumer plugins explicitly

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -17,7 +17,9 @@ import { ConsumerIntegrationTester } from './infrastructure/auth/ConsumerIntegra
 import { ConsumerPosterRegistryImpl } from './infrastructure/consumers/ConsumerPosterRegistryImpl.js'
 import { NoOpTenantService } from './infrastructure/tenant/NoOpTenantService.js'
 import type { TenantService } from './application/ports/TenantService.js'
-import { registry as consumerRegistry, type ConsumerContext, type IncomingMessage, type Workspace } from '@supaproxy/consumers'
+import { registry as consumerRegistry, slackPlugin, type ConsumerContext, type IncomingMessage, type Workspace } from '@supaproxy/consumers'
+
+consumerRegistry.register(slackPlugin)
 import pino from 'pino'
 
 const log = pino({ name: 'container' })


### PR DESCRIPTION
## Summary

@supaproxy/consumers@0.2.0 split types from plugins (same pattern as @supaproxy/connections). The root import no longer auto-registers plugins, so the server must register them explicitly.

Without this fix, the "Add consumer" modal shows empty because the `/api/consumers/types` endpoint returns `[]`.

## Test plan

- [ ] Open "Add consumer" modal — Slack and API tabs should appear
- [ ] Add a consumer — should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)