### PR TITLE
feat: /api/route endpoint and fix AI redirect detection

### DIFF
--- a/src/__tests__/mocks.ts
+++ b/src/__tests__/mocks.ts
@@ -138,6 +138,7 @@ export function mockConversationRepo(): ConversationRepository {
     findByExternalThreadId: vi.fn().mockResolvedValue(null),
     create: vi.fn().mockResolvedValue(undefined),
     updateStatus: vi.fn().mockResolvedValue(undefined),
+    updateRouting: vi.fn().mockResolvedValue(undefined),
     reopenFromCold: vi.fn().mockResolvedValue(undefined),
     closeConversation: vi.fn().mockResolvedValue(undefined),
     listWithStats: vi.fn().mockResolvedValue({ rows: [], total: 0 }),

--- a/src/app.ts
+++ b/src/app.ts
@@ -70,6 +70,7 @@ export function createApp(container: Container, corsOrigins?: string[]): Hono {
   app.route('/', container.conversationRoutes)
   app.route('/', container.connectorRoutes)
   app.route('/', container.queryRoutes)
+  app.route('/', container.routeRoutes)
 
   // WhatsApp webhook (no auth — Meta needs direct access)
   app.get('/api/webhooks/whatsapp', async (c) => {

--- a/src/application/conversation/ManageConversationUseCase.ts
+++ b/src/application/conversation/ManageConversationUseCase.ts
@@ -49,4 +49,8 @@ export class ManageConversationUseCase {
   async getHistory(conversationId: string): Promise<Array<{ role: 'user' | 'assistant'; content: string }>> {
     return this.conversationRepo.findMessages(conversationId)
   }
+
+  async setRouting(conversationId: string, routedFrom: string, routedTo: string, routeReason: string): Promise<void> {
+    await this.conversationRepo.updateRouting(conversationId, routedFrom, routedTo, routeReason)
+  }
 }

--- a/src/application/ports/SessionStore.ts
+++ b/src/application/ports/SessionStore.ts
@@ -2,6 +2,7 @@ export interface RoutingSession {
   workspaceId: string
   lastMessageAt: number
   routedFrom: string | null
+  routedFromConversationId?: string
   pendingRedirect?: boolean
 }
 

--- a/src/application/query/ExecuteQueryUseCase.ts
+++ b/src/application/query/ExecuteQueryUseCase.ts
@@ -63,6 +63,8 @@ interface QueryMeta {
   sessionId?: string
   systemPromptOverride?: string
   skipTools?: boolean
+  routedFrom?: string
+  routedFromConversationId?: string
 }
 
 export class ExecuteQueryUseCase {
@@ -86,6 +88,12 @@ export class ExecuteQueryUseCase {
     const conversationId = meta.conversationId || await this.conversationUseCase.findOrCreate(
       workspaceId, meta.consumerType, sessionId, meta.userName, meta.channel
     )
+
+    // Record routing metadata if this conversation was routed from another workspace
+    if (meta.routedFrom) {
+      await this.conversationUseCase.setRouting(conversationId, meta.routedFrom, workspace.name, '')
+    }
+
     const history = await this.conversationUseCase.getHistory(conversationId)
 
     let provider: ProviderPlugin

--- a/src/application/routing/RouteMessageUseCase.test.ts
+++ b/src/application/routing/RouteMessageUseCase.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mockOrgRepo, mockWorkspaceRepo, stubWorkspace } from '../../__tests__/mocks.js'
+import { mockOrgRepo, mockWorkspaceRepo, mockConversationRepo, stubWorkspace } from '../../__tests__/mocks.js'
 import { RouteMessageUseCase } from './RouteMessageUseCase.js'
 import type { SessionStore } from '../ports/SessionStore.js'
 import type { ExecuteQueryUseCase } from '../query/ExecuteQueryUseCase.js'
@@ -50,7 +50,7 @@ describe('RouteMessageUseCase', () => {
     workspaceRepo = mockWorkspaceRepo()
     sessionStore = mockSessionStore()
     executeQuery = mockExecuteQuery()
-    useCase = new RouteMessageUseCase(workspaceRepo, orgRepo, sessionStore, executeQuery)
+    useCase = new RouteMessageUseCase(workspaceRepo, orgRepo, mockConversationRepo(), sessionStore, executeQuery)
   })
 
   it('uses existing session to route directly to workspace', async () => {

--- a/src/application/routing/RouteMessageUseCase.test.ts
+++ b/src/application/routing/RouteMessageUseCase.test.ts
@@ -3,7 +3,6 @@ import { mockOrgRepo, mockWorkspaceRepo, stubWorkspace } from '../../__tests__/m
 import { RouteMessageUseCase } from './RouteMessageUseCase.js'
 import type { SessionStore } from '../ports/SessionStore.js'
 import type { ExecuteQueryUseCase } from '../query/ExecuteQueryUseCase.js'
-import type { registry as ProviderRegistryType } from '@supaproxy/providers'
 
 function mockSessionStore(): SessionStore {
   return {
@@ -44,7 +43,6 @@ describe('RouteMessageUseCase', () => {
   let workspaceRepo: ReturnType<typeof mockWorkspaceRepo>
   let sessionStore: ReturnType<typeof mockSessionStore>
   let executeQuery: ReturnType<typeof mockExecuteQuery>
-  let providerRegistry: typeof ProviderRegistryType
   let useCase: RouteMessageUseCase
 
   beforeEach(() => {
@@ -52,13 +50,7 @@ describe('RouteMessageUseCase', () => {
     workspaceRepo = mockWorkspaceRepo()
     sessionStore = mockSessionStore()
     executeQuery = mockExecuteQuery()
-    providerRegistry = {
-      get: vi.fn().mockReturnValue({
-        models: [{ id: 'claude-haiku-4-20250506', label: 'Haiku' }],
-        createSimpleMessage: vi.fn().mockResolvedValue('no'),
-      }),
-    } as unknown as typeof ProviderRegistryType
-    useCase = new RouteMessageUseCase(workspaceRepo, orgRepo, sessionStore, executeQuery, providerRegistry)
+    useCase = new RouteMessageUseCase(workspaceRepo, orgRepo, sessionStore, executeQuery)
   })
 
   it('uses existing session to route directly to workspace', async () => {

--- a/src/application/routing/RouteMessageUseCase.ts
+++ b/src/application/routing/RouteMessageUseCase.ts
@@ -3,7 +3,6 @@ import type { OrganisationRepository } from '../../domain/organisation/repositor
 import type { SessionStore, RoutingSession } from '../ports/SessionStore.js'
 import { buildSessionKey } from '../ports/SessionStore.js'
 import type { ExecuteQueryUseCase } from '../query/ExecuteQueryUseCase.js'
-import type { registry as ProviderRegistryType } from '@supaproxy/providers'
 import { ReceptionistPromptBuilder } from './ReceptionistPromptBuilder.js'
 import { NotFoundError } from '../../domain/shared/errors.js'
 import pino from 'pino'
@@ -12,13 +11,7 @@ const log = pino({ name: 'route-message' })
 
 const SESSION_TTL_SECONDS = 1800 // 30 minutes
 
-const REDIRECT_INTENT_PROMPT = `You are a redirect intent classifier. The user was asked if they want to be redirected to a different department. Based on their response, answer only "yes" or "no".
-
-Previous AI message: "That falls outside what I can help with here. Would you like me to redirect you to someone who can help?"
-
-User response: "{{query}}"
-
-Does the user want to be redirected? Answer only "yes" or "no".`
+const REDIRECT_INTENT_PROMPT = `The user was asked: "Would you like me to redirect you to someone who can help?" They responded: "{{query}}" — do they want to be redirected?`
 
 interface RouteMessageInput {
   orgId: string
@@ -45,7 +38,6 @@ export class RouteMessageUseCase {
     private readonly orgRepo: OrganisationRepository,
     private readonly sessionStore: SessionStore,
     private readonly executeQueryUseCase: ExecuteQueryUseCase,
-    private readonly providerRegistry: typeof ProviderRegistryType,
   ) {}
 
   async execute(input: RouteMessageInput): Promise<RouteMessageOutput> {
@@ -97,33 +89,20 @@ export class RouteMessageUseCase {
 
   private async checkRedirectIntent(query: string, orgId: string): Promise<boolean> {
     try {
-      const { provider, apiKey, model } = await this.resolveProvider(orgId)
+      const defaultWs = await this.workspaceRepo.findDefaultByOrg(orgId)
+      if (!defaultWs) return false
+
       const prompt = REDIRECT_INTENT_PROMPT.replace('{{query}}', query)
-      const response = await provider.createSimpleMessage({
-        apiKey,
-        model,
-        maxTokens: 10,
-        prompt,
+      const result = await this.executeQueryUseCase.execute(defaultWs.id, prompt, {
+        consumerType: 'system',
+        systemPromptOverride: 'You are a redirect intent classifier. Answer only "yes" or "no".',
+        skipTools: true,
       })
-      return response.toLowerCase().trim().startsWith('yes')
+      return result.answer.toLowerCase().trim().startsWith('yes')
     } catch (err) {
       log.warn({ error: (err as Error).message }, 'Redirect intent check failed, defaulting to no')
       return false
     }
-  }
-
-  private async resolveProvider(orgId: string): Promise<{ provider: ReturnType<typeof ProviderRegistryType.get>; apiKey: string; model: string }> {
-    const settings = await this.orgRepo.getSettingValues(['ai_provider_type', 'ai_api_key', 'anthropic_api_key'])
-    const providerType = settings['ai_provider_type']
-    if (!providerType) throw new Error('No AI provider configured')
-    const apiKey = settings['ai_api_key'] || settings['anthropic_api_key']
-    if (!apiKey) throw new Error('No AI API key configured')
-    const provider = this.providerRegistry.get(providerType)
-
-    // Use the default workspace's model for intent classification
-    const defaultWs = await this.workspaceRepo.findDefaultByOrg(orgId)
-    const model = defaultWs?.model || 'claude-sonnet-4-20250514'
-    return { provider, apiKey, model }
   }
 
   private async routeViaReceptionist(input: RouteMessageInput, sessionKey: string): Promise<RouteMessageOutput> {

--- a/src/application/routing/RouteMessageUseCase.ts
+++ b/src/application/routing/RouteMessageUseCase.ts
@@ -1,5 +1,6 @@
 import type { WorkspaceRepository } from '../../domain/workspace/repository.js'
 import type { OrganisationRepository } from '../../domain/organisation/repository.js'
+import type { ConversationRepository } from '../../domain/conversation/repository.js'
 import type { SessionStore, RoutingSession } from '../ports/SessionStore.js'
 import { buildSessionKey } from '../ports/SessionStore.js'
 import type { ExecuteQueryUseCase } from '../query/ExecuteQueryUseCase.js'
@@ -36,6 +37,7 @@ export class RouteMessageUseCase {
   constructor(
     private readonly workspaceRepo: WorkspaceRepository,
     private readonly orgRepo: OrganisationRepository,
+    private readonly conversationRepo: ConversationRepository,
     private readonly sessionStore: SessionStore,
     private readonly executeQueryUseCase: ExecuteQueryUseCase,
   ) {}
@@ -172,6 +174,11 @@ export class RouteMessageUseCase {
 
       // Create session pointing to the target workspace
       await this.createSession(sessionKey, targetWorkspaceId, defaultWs.id)
+
+      // Record routing metadata on the conversation
+      await this.conversationRepo.updateRouting(
+        result.conversationId, defaultWs.id, targetWorkspaceId, routeReason,
+      )
 
       // Clean the routing directive from the visible answer and add routing indicator
       const cleanAnswer = this.cleanRoutingDirective(result.answer)

--- a/src/application/routing/RouteMessageUseCase.ts
+++ b/src/application/routing/RouteMessageUseCase.ts
@@ -57,26 +57,16 @@ export class RouteMessageUseCase {
     if (existingSession) {
       // If the AI previously offered a redirect, ask the receptionist if the user accepted
       if (existingSession.pendingRedirect) {
+        log.info({ sessionKey, query: input.query }, 'Pending redirect, checking intent via AI')
         const wantsRedirect = await this.checkRedirectIntent(input.query, input.orgId)
+        log.info({ sessionKey, wantsRedirect }, 'Redirect intent result')
         if (wantsRedirect) {
-          log.info({ sessionKey, from: existingSession.workspaceId }, 'User confirmed redirect via AI intent check')
           await this.sessionStore.delete(sessionKey)
           return this.routeViaReceptionist(input, sessionKey)
         }
-        // User declined redirect, clear the pending flag and continue
-        await this.sessionStore.set(sessionKey, {
-          ...existingSession,
-          lastMessageAt: Date.now(),
-          pendingRedirect: false,
-        }, SESSION_TTL_SECONDS)
       }
 
-      // Refresh the session TTL
-      await this.sessionStore.set(sessionKey, {
-        ...existingSession,
-        lastMessageAt: Date.now(),
-      }, SESSION_TTL_SECONDS)
-
+      // Execute in the current workspace
       const result = await this.executeQueryUseCase.execute(existingSession.workspaceId, input.query, {
         consumerType: input.consumerType,
         channel: input.entryPoint,
@@ -84,14 +74,14 @@ export class RouteMessageUseCase {
         userName: input.userName,
       })
 
-      // Check if the AI offered a redirect (scope guardrail triggered)
-      if (this.isRedirectOffer(result.answer)) {
-        await this.sessionStore.set(sessionKey, {
-          ...existingSession,
-          lastMessageAt: Date.now(),
-          pendingRedirect: true,
-        }, SESSION_TTL_SECONDS)
-      }
+      // Update session: set pendingRedirect if scope guardrail triggered, clear otherwise
+      const redirectOffered = this.isRedirectOffer(result.answer)
+      await this.sessionStore.set(sessionKey, {
+        workspaceId: existingSession.workspaceId,
+        lastMessageAt: Date.now(),
+        routedFrom: existingSession.routedFrom,
+        pendingRedirect: redirectOffered,
+      }, SESSION_TTL_SECONDS)
 
       return {
         answer: result.answer,
@@ -130,10 +120,10 @@ export class RouteMessageUseCase {
     if (!apiKey) throw new Error('No AI API key configured')
     const provider = this.providerRegistry.get(providerType)
 
-    // Use the cheapest model for intent classification
-    const models = provider.models
-    const cheapModel = models.find(m => m.id.includes('haiku')) || models[0]
-    return { provider, apiKey, model: cheapModel?.id || 'claude-haiku-4-20250506' }
+    // Use the default workspace's model for intent classification
+    const defaultWs = await this.workspaceRepo.findDefaultByOrg(orgId)
+    const model = defaultWs?.model || 'claude-sonnet-4-20250514'
+    return { provider, apiKey, model }
   }
 
   private async routeViaReceptionist(input: RouteMessageInput, sessionKey: string): Promise<RouteMessageOutput> {

--- a/src/application/routing/RouteMessageUseCase.ts
+++ b/src/application/routing/RouteMessageUseCase.ts
@@ -66,6 +66,8 @@ export class RouteMessageUseCase {
         channel: input.entryPoint,
         userId: input.userId,
         userName: input.userName,
+        routedFrom: existingSession.routedFrom || undefined,
+        routedFromConversationId: existingSession.routedFromConversationId || undefined,
       })
 
       // Update session: set pendingRedirect if scope guardrail triggered, clear otherwise
@@ -172,12 +174,17 @@ export class RouteMessageUseCase {
         }
       }
 
-      // Create session pointing to the target workspace
-      await this.createSession(sessionKey, targetWorkspaceId, defaultWs.id)
+      // Create session pointing to the target workspace, with source conversation ID
+      await this.sessionStore.set(sessionKey, {
+        workspaceId: targetWorkspaceId,
+        lastMessageAt: Date.now(),
+        routedFrom: defaultWs.name,
+        routedFromConversationId: result.conversationId,
+      }, SESSION_TTL_SECONDS)
 
-      // Record routing metadata on the conversation
+      // Record routing metadata on the conversation (store names, not IDs)
       await this.conversationRepo.updateRouting(
-        result.conversationId, defaultWs.id, targetWorkspaceId, routeReason,
+        result.conversationId, defaultWs.name, targetWs.name, routeReason,
       )
 
       // Clean the routing directive from the visible answer and add routing indicator

--- a/src/container.ts
+++ b/src/container.ts
@@ -85,6 +85,7 @@ import { createConversationRoutes } from './presentation/routes/conversations.js
 import { createConnectorRoutes } from './presentation/routes/connectors.js'
 import { createQueryRoutes } from './presentation/routes/query.js'
 import { createQueueRoutes } from './presentation/routes/queues.js'
+import { createRouteRoutes } from './presentation/routes/route.js'
 
 export function createContainer(pool: mysql.Pool, options?: { tenantService?: TenantService }) {
   // Tenant service — defaults to NoOp (single-tenant) for open-source.
@@ -238,6 +239,7 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
   const connectorRoutes = createConnectorRoutes({ testMcpConnectionUseCase, saveMcpConnectionUseCase, bindConsumerChannelUseCase, connectConsumerUseCase, workspaceRepo, tenantService, requireAuth })
   const queryRoutes = createQueryRoutes({ executeQueryUseCase, workspaceRepo, tenantService, requireAuth })
   const queueRoutes = createQueueRoutes({ manageQueuesUseCase, queueService, requireAuth })
+  const routeRoutes = createRouteRoutes({ routeMessageUseCase, requireAuth })
 
   const container = {
     // Infrastructure
@@ -257,7 +259,7 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
     testMcpConnectionUseCase, saveMcpConnectionUseCase, bindConsumerChannelUseCase, connectConsumerUseCase,
     executeQueryUseCase, routeMessageUseCase, manageQueuesUseCase,
     // Routes
-    authRoutes, orgRoutes, workspaceRoutes, conversationRoutes, connectorRoutes, queryRoutes, queueRoutes,
+    authRoutes, orgRoutes, workspaceRoutes, conversationRoutes, connectorRoutes, queryRoutes, queueRoutes, routeRoutes,
   }
 
   return container

--- a/src/container.ts
+++ b/src/container.ts
@@ -228,7 +228,7 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
 
   const executeQueryUseCase = new ExecuteQueryUseCase(workspaceRepo, orgRepo, auditRepo, providerRegistry, mcpFactory, manageConversationUseCase, resolveGuardrails)
   const sessionStore = new RedisSessionStore(REDIS_HOST, REDIS_PORT)
-  const routeMessageUseCase = new RouteMessageUseCase(workspaceRepo, orgRepo, sessionStore, executeQueryUseCase)
+  const routeMessageUseCase = new RouteMessageUseCase(workspaceRepo, orgRepo, conversationRepo, sessionStore, executeQueryUseCase)
   const manageQueuesUseCase = new ManageQueuesUseCase(queueService)
 
   // Build routes

--- a/src/container.ts
+++ b/src/container.ts
@@ -228,7 +228,7 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
 
   const executeQueryUseCase = new ExecuteQueryUseCase(workspaceRepo, orgRepo, auditRepo, providerRegistry, mcpFactory, manageConversationUseCase, resolveGuardrails)
   const sessionStore = new RedisSessionStore(REDIS_HOST, REDIS_PORT)
-  const routeMessageUseCase = new RouteMessageUseCase(workspaceRepo, orgRepo, sessionStore, executeQueryUseCase, providerRegistry)
+  const routeMessageUseCase = new RouteMessageUseCase(workspaceRepo, orgRepo, sessionStore, executeQueryUseCase)
   const manageQueuesUseCase = new ManageQueuesUseCase(queueService)
 
   // Build routes

--- a/src/domain/conversation/repository.ts
+++ b/src/domain/conversation/repository.ts
@@ -101,6 +101,7 @@ export interface ConversationRepository {
   findByExternalThreadId(externalThreadId: string, statuses: string[]): Promise<ConversationData | null>
   create(data: { id: string; workspaceId: string; consumerType: string; externalThreadId: string; userName?: string; channel?: string; parentId?: string }): Promise<void>
   updateStatus(id: string, status: string): Promise<void>
+  updateRouting(id: string, routedFrom: string, routedTo: string, routeReason: string): Promise<void>
   reopenFromCold(id: string): Promise<void>
   closeConversation(id: string): Promise<void>
 

--- a/src/infrastructure/persistence/mysql/MysqlConversationRepository.ts
+++ b/src/infrastructure/persistence/mysql/MysqlConversationRepository.ts
@@ -67,6 +67,13 @@ export class MysqlConversationRepository implements ConversationRepository {
     await this.pool.execute('UPDATE conversations SET status = ?, updated_at = NOW() WHERE id = ?', [status, id])
   }
 
+  async updateRouting(id: string, routedFrom: string, routedTo: string, routeReason: string): Promise<void> {
+    await this.pool.execute(
+      'UPDATE conversations SET routed_from = ?, routed_to = ?, route_reason = ?, updated_at = NOW() WHERE id = ?',
+      [routedFrom, routedTo, routeReason, id]
+    )
+  }
+
   async reopenFromCold(id: string): Promise<void> {
     await this.pool.execute(
       "UPDATE conversations SET status = 'open', cold_at = NULL, updated_at = NOW() WHERE id = ?", [id]

--- a/src/presentation/routes/route.ts
+++ b/src/presentation/routes/route.ts
@@ -1,0 +1,52 @@
+import { Hono } from 'hono'
+import { z } from 'zod'
+import type { RouteMessageUseCase } from '../../application/routing/RouteMessageUseCase.js'
+import { parseBody } from '../middleware/validate.js'
+import { type AuthUser, type AuthEnv } from '../middleware/auth.js'
+import { NotFoundError } from '../../domain/shared/errors.js'
+
+const routeBodySchema = z.object({
+  query: z.string().min(1, 'Query is required').max(10000),
+})
+
+interface RouteRouteDeps {
+  routeMessageUseCase: RouteMessageUseCase
+  requireAuth: (c: import('hono').Context, next: import('hono').Next) => Promise<Response | void>
+}
+
+export function createRouteRoutes(deps: RouteRouteDeps) {
+  const route = new Hono<AuthEnv>()
+
+  route.use('/api/route', deps.requireAuth)
+
+  route.post('/api/route', async (c) => {
+    const parsed = await parseBody(c, routeBodySchema)
+    if (!parsed.success) return parsed.response
+
+    const user = c.get('user') as AuthUser
+
+    try {
+      const result = await deps.routeMessageUseCase.execute({
+        orgId: user.org_id,
+        query: parsed.data.query,
+        consumerType: 'dashboard',
+        entryPoint: 'test',
+        userId: user.id,
+        userName: user.name,
+      })
+
+      return c.json({
+        answer: result.answer,
+        conversation_id: result.conversationId,
+        workspace_id: result.workspaceId,
+        routed: result.routed,
+        routed_to: result.routedTo || null,
+      })
+    } catch (err) {
+      if (err instanceof NotFoundError) return c.json({ error: err.message }, 404)
+      throw err
+    }
+  })
+
+  return route
+}


### PR DESCRIPTION
## Summary

- New `POST /api/route` endpoint that calls `RouteMessageUseCase` directly, authenticated via session cookie
- Fix redirect intent check: was using hardcoded Haiku model ID that doesn't exist, now uses the default workspace's model
- Fix session state bug: `pendingRedirect` flag was being overwritten by stale session spread on TTL refresh

## Tested flow

1. "I need to file a car insurance claim" → receptionist routes to Motor Claims
2. "Tell me about the sun" → scope guardrail blocks, offers redirect
3. "Sure, why not" → AI detects redirect intent, clears session, back to receptionist

## Test plan

- [x] 170 unit tests pass
- [x] Full routing flow tested end-to-end via `/api/route`
- [x] Scope enforcement blocks off-topic questions
- [x] AI-based redirect detection works ("Sure, why not" correctly interpreted)
- [x] Session correctly cleared on redirect, receptionist re-engages

🤖 Generated with [Claude Code](https://claude.com/claude-code)