### PR TITLE
refactor: delegate MCP to @supaproxy/connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@hono/zod-openapi": "0.18.4",
     "@modelcontextprotocol/sdk": "^1.12.0",
     "@slack/bolt": "^4.2.0",
+    "@supaproxy/connections": "^0.2.0",
     "@supaproxy/consumers": "^0.3.0",
     "@supaproxy/guardrails": "^0.2.1",
     "@supaproxy/providers": "0.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ dependencies:
   '@slack/bolt':
     specifier: ^4.2.0
     version: 4.7.0(@types/express@5.0.6)
+  '@supaproxy/connections':
+    specifier: ^0.2.0
+    version: 0.2.0(zod@3.25.76)
   '@supaproxy/consumers':
     specifier: ^0.3.0
     version: 0.3.0(@slack/bolt@4.7.0)
@@ -876,6 +879,17 @@ packages:
       retry: 0.13.1
     transitivePeerDependencies:
       - debug
+    dev: false
+
+  /@supaproxy/connections@0.2.0(zod@3.25.76):
+    resolution: {integrity: sha512-FbvkUXDMssnfssS08U6W696AmjoeoiWULZc1KZ8551WHZgVVWmm8YDNYDMgj3YX044krfhaRT3bk8rnurhUS3w==}
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      pino: 9.14.0
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+      - zod
     dev: false
 
   /@supaproxy/consumers@0.3.0(@slack/bolt@4.7.0):

--- a/src/application/conversation/LifecycleUseCase.test.ts
+++ b/src/application/conversation/LifecycleUseCase.test.ts
@@ -141,7 +141,7 @@ describe('LifecycleUseCase', () => {
         { role: 'user', content: 'hello' },
       ])
       vi.mocked(orgRepo.getSettingValues).mockResolvedValue({
-        ai_api_key: null,
+        ai_api_key: '',
         ai_provider_type: 'anthropic',
       })
 
@@ -177,7 +177,7 @@ describe('LifecycleUseCase', () => {
       ])
       vi.mocked(orgRepo.getSettingValues).mockResolvedValue({
         ai_api_key: 'sk-test',
-        ai_provider_type: null,
+        ai_provider_type: '',
       })
 
       await useCase.sendColdMessage(target)
@@ -336,7 +336,7 @@ describe('LifecycleUseCase', () => {
       })
       vi.mocked(conversationRepo.getWorkspaceModel).mockResolvedValue('claude-sonnet-4-20250514')
       vi.mocked(orgRepo.getSettingValues).mockResolvedValue({
-        ai_api_key: null,
+        ai_api_key: '',
         ai_provider_type: 'anthropic',
       })
 

--- a/src/application/query/ExecuteQueryUseCase.test.ts
+++ b/src/application/query/ExecuteQueryUseCase.test.ts
@@ -95,7 +95,7 @@ describe('ExecuteQueryUseCase', () => {
     vi.mocked(orgRepo.getSettingValues).mockResolvedValue({
       ai_provider_type: 'anthropic',
       ai_api_key: 'sk-test-key',
-      anthropic_api_key: null,
+      anthropic_api_key: '',
     })
   })
 
@@ -109,9 +109,9 @@ describe('ExecuteQueryUseCase', () => {
 
   it('returns error message when no AI provider is configured', async () => {
     vi.mocked(orgRepo.getSettingValues).mockResolvedValue({
-      ai_provider_type: null,
-      ai_api_key: null,
-      anthropic_api_key: null,
+      ai_provider_type: '',
+      ai_api_key: '',
+      anthropic_api_key: '',
     })
     const useCase = buildUseCase()
 
@@ -124,8 +124,8 @@ describe('ExecuteQueryUseCase', () => {
   it('returns error when API key is missing', async () => {
     vi.mocked(orgRepo.getSettingValues).mockResolvedValue({
       ai_provider_type: 'anthropic',
-      ai_api_key: null,
-      anthropic_api_key: null,
+      ai_api_key: '',
+      anthropic_api_key: '',
     })
     const useCase = buildUseCase()
 
@@ -181,9 +181,12 @@ describe('ExecuteQueryUseCase', () => {
 
   it('blocks query when guardrail returns block action', async () => {
     const guardrail: GuardrailPlugin = {
-      type: 'pattern',
+      id: 'pattern',
       name: 'test-guard',
       description: 'Test',
+      version: '0.1.0',
+      author: 'test',
+      stage: 'pre-llm',
       configSchema: { fields: [] },
       process: vi.fn().mockResolvedValue({
         action: 'block',
@@ -206,9 +209,12 @@ describe('ExecuteQueryUseCase', () => {
 
   it('uses modified query when guardrail modifies input', async () => {
     const guardrail: GuardrailPlugin = {
-      type: 'pattern',
+      id: 'pattern',
       name: 'sanitiser',
       description: 'Sanitise',
+      version: '0.1.0',
+      author: 'test',
+      stage: 'pre-llm',
       configSchema: { fields: [] },
       process: vi.fn().mockResolvedValue({
         action: 'pass',

--- a/src/infrastructure/mcp/McpClientFactoryImpl.ts
+++ b/src/infrastructure/mcp/McpClientFactoryImpl.ts
@@ -1,142 +1,75 @@
-import { Client } from '@modelcontextprotocol/sdk/client/index.js'
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+import { httpPlugin, stdioPlugin } from '@supaproxy/connections/plugins'
 import type { McpClientFactory, McpConnection, McpToolDefinition, McpToolCallResult } from '../../application/ports/McpClient.js'
-import pino from 'pino'
+import type { McpConnection as PluginConnection } from '@supaproxy/connections'
 
-const log = pino({ name: 'mcp-client' })
-
-interface JsonRpcResponse {
-  jsonrpc: string
-  id: number
-  result?: Record<string, unknown>
-  error?: { message: string; code?: number }
-  message?: string
-}
-
-interface JsonRpcToolsResponse extends JsonRpcResponse {
-  result?: { tools?: Array<{ name: string; description?: string; inputSchema?: Record<string, unknown> }> } & Record<string, unknown>
-}
-
-class HttpMcpConnection implements McpConnection {
-  public readonly tools: McpToolDefinition[] = []
-
-  constructor(
-    private readonly url: string,
-    private readonly headers: Record<string, string>,
-    tools: McpToolDefinition[],
-  ) {
-    this.tools = tools
-  }
-
-  async callTool(name: string, args: Record<string, unknown>): Promise<McpToolCallResult> {
-    const reqId = `sp-call-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
-    const res = await fetch(this.url, {
-      method: 'POST',
-      headers: { ...this.headers, 'x-moo-request-id': reqId },
-      body: JSON.stringify({ jsonrpc: '2.0', id: Date.now(), method: 'tools/call', params: { name, arguments: args } }),
-      signal: AbortSignal.timeout(30000),
-    })
-    if (!res.ok) throw new Error('HTTP ' + res.status + ': ' + res.statusText)
-    const data = await res.json() as JsonRpcResponse
-    if (data.error) throw new Error(`MCP error: ${data.error.message}`)
-    const result = data.result as unknown as McpToolCallResult
-    return { content: result?.content || [], isError: Boolean(result?.isError) }
-  }
-
-  async close(): Promise<void> { /* HTTP connections are stateless */ }
-}
-
-class StdioMcpConnection implements McpConnection {
-  public readonly tools: McpToolDefinition[] = []
-
-  constructor(
-    private readonly client: Client,
-    private readonly transport: StdioClientTransport,
-    tools: McpToolDefinition[],
-  ) {
-    this.tools = tools
-  }
-
-  async callTool(name: string, args: Record<string, unknown>): Promise<McpToolCallResult> {
-    const result = await this.client.callTool({ name, arguments: args })
-    const content = result.content as Array<{ type: string; text?: string }> || []
-    return { content, isError: Boolean(result.isError) }
-  }
-
-  async close(): Promise<void> {
-    try { await this.client.close() } catch { /* ignore */ }
-  }
-}
-
+/**
+ * Adapter that delegates to @supaproxy/connections plugins.
+ *
+ * The server does not implement MCP protocol details. It delegates
+ * to the connection plugins which own the transport, protocol version,
+ * timeouts, and header handling.
+ */
 export class McpClientFactoryImpl implements McpClientFactory {
-  private async httpRequest(url: string, method: string, params: Record<string, unknown>, headers: Record<string, string>): Promise<Record<string, unknown>> {
-    const reqId = `sp-${method.replace('/', '-')}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
-    const res = await fetch(url, {
-      method: 'POST',
-      headers: { ...headers, 'x-moo-request-id': reqId },
-      body: JSON.stringify({ jsonrpc: '2.0', id: Date.now(), method, params }),
-      signal: AbortSignal.timeout(30000),
-    })
-    if (!res.ok) throw new Error('HTTP ' + res.status + ': ' + res.statusText)
-    const data = await res.json() as JsonRpcResponse
-    if (data.error) throw new Error(`MCP error: ${data.error.message}`)
-    return data.result || {}
-  }
 
   async connectHttp(url: string, extraHeaders?: Record<string, string>, clientName?: string): Promise<McpConnection> {
-    const headers: Record<string, string> = { 'Content-Type': 'application/json', ...(extraHeaders || {}) }
+    const config: Record<string, string> = {
+      url,
+      name: clientName || 'supaproxy',
+    }
+    if (extraHeaders) {
+      config.headers = JSON.stringify(extraHeaders)
+    }
 
-    await this.httpRequest(url, 'initialize', {
-      protocolVersion: '2024-11-05',
-      capabilities: {},
-      clientInfo: { name: clientName || 'supaproxy', version: '1.0.0' },
-    }, headers)
-
-    const toolsResult = await this.httpRequest(url, 'tools/list', {}, headers) as { tools?: Array<{ name: string; description?: string; inputSchema?: Record<string, unknown> }> }
-    const tools: McpToolDefinition[] = (toolsResult.tools || []).map(t => ({
-      name: t.name,
-      description: t.description || '',
-      inputSchema: t.inputSchema || { type: 'object', properties: {} },
-    }))
-
-    return new HttpMcpConnection(url, headers, tools)
+    const conn = await httpPlugin.connect(config)
+    return this.adaptConnection(conn)
   }
 
   async connectStdio(command: string, args: string[], env?: Record<string, string>, clientName?: string): Promise<McpConnection> {
-    const transport = new StdioClientTransport({
+    const config: Record<string, string> = {
       command,
-      args,
-      env: { ...process.env, ...(env || {}) } as Record<string, string>,
-    })
+      args: args.join(' '),
+      name: clientName || 'supaproxy',
+    }
+    if (env) {
+      config.env = JSON.stringify(env)
+    }
 
-    const client = new Client({ name: clientName || 'supaproxy', version: '1.0.0' })
-    await client.connect(transport)
-
-    const toolsResult = await client.listTools()
-    const tools: McpToolDefinition[] = toolsResult.tools.map(t => ({
-      name: t.name,
-      description: t.description || '',
-      inputSchema: t.inputSchema,
-    }))
-
-    return new StdioMcpConnection(client, transport, tools)
+    const conn = await stdioPlugin.connect(config)
+    return this.adaptConnection(conn)
   }
 
   async testHttp(url: string, extraHeaders?: Record<string, string>): Promise<{ ok: boolean; tools: number; server: string; toolNames: string[]; error?: string }> {
-    try {
-      const headers: Record<string, string> = { 'Content-Type': 'application/json', ...extraHeaders }
-      const initResult = await this.httpRequest(url, 'initialize', {
-        protocolVersion: '2024-11-05',
-        capabilities: {},
-        clientInfo: { name: 'supaproxy-test', version: '1.0.0' },
-      }, headers)
+    const config: Record<string, string> = { url, name: 'supaproxy-test' }
+    if (extraHeaders) {
+      config.headers = JSON.stringify(extraHeaders)
+    }
 
-      const toolsResult = await this.httpRequest(url, 'tools/list', {}, headers) as { tools?: Array<{ name: string }> }
-      const tools = toolsResult.tools || []
-      const serverInfo = initResult.serverInfo as Record<string, unknown> | undefined
-      return { ok: true, tools: tools.length, server: (serverInfo?.name as string) || 'unknown', toolNames: tools.map(t => t.name) }
-    } catch (err) {
-      return { ok: false, tools: 0, server: '', toolNames: [], error: `Connection failed: ${(err as Error).message}` }
+    const result = await httpPlugin.test(config)
+    return {
+      ok: result.ok,
+      tools: result.tools || 0,
+      server: result.server || '',
+      toolNames: result.toolNames || [],
+      error: result.error,
+    }
+  }
+
+  private adaptConnection(conn: PluginConnection): McpConnection {
+    const tools: McpToolDefinition[] = conn.tools.map(t => ({
+      name: t.name,
+      description: t.description,
+      inputSchema: t.inputSchema,
+    }))
+
+    return {
+      tools,
+      async callTool(name: string, args: Record<string, unknown>): Promise<McpToolCallResult> {
+        const result = await conn.callTool(name, args)
+        return { content: result.content, isError: result.isError }
+      },
+      async close(): Promise<void> {
+        await conn.close()
+      },
     }
   }
 }


### PR DESCRIPTION
## Summary

- McpClientFactoryImpl now delegates to `httpPlugin` and `stdioPlugin` from `@supaproxy/connections`
- Removed all hardcoded MCP protocol details from the server:
  - `x-moo-request-id` header (not in MCP spec)
  - `2024-11-05` protocol version
  - `30000` timeout
  - `1.0.0` client version
  - Duplicate JSON-RPC implementation
- Server reduced from 142 lines to 73 lines (thin adapter only)
- Also updated `@supaproxy/connections` HTTP plugin: configurable headers, timeout, res.ok check
- Fixed type errors in test files

## Test plan

- [x] TypeScript compiles with zero errors
- [x] All 213 tests pass
- [x] McpClientFactory port interface unchanged (no downstream breaks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)