### PR TITLE
refactor: externalise all hardcoded config, prompts, and pricing

### DIFF
--- a/src/application/auth/SignupUseCase.test.ts
+++ b/src/application/auth/SignupUseCase.test.ts
@@ -18,14 +18,11 @@ describe('SignupUseCase', () => {
     adminName: 'Alice',
     adminEmail: 'alice@acme.com',
     adminPassword: 'securepassword',
-    workspaceName: 'Support',
-    teamName: 'Engineering',
   }
 
-  it('creates org, user, #general default workspace, and user workspace', async () => {
+  it('creates org, user, and #general default workspace', async () => {
     const { orgRepo, workspaceRepo, passwordService, tokenService, useCase } = setup()
     vi.mocked(orgRepo.userExistsByEmail).mockResolvedValue(false)
-    vi.mocked(orgRepo.findTeamByName).mockResolvedValue(null)
     vi.mocked(passwordService.hash).mockResolvedValue('hashed-pw')
     vi.mocked(tokenService.sign).mockReturnValue('signup-token')
 
@@ -36,41 +33,18 @@ describe('SignupUseCase', () => {
     expect(passwordService.hash).toHaveBeenCalledWith('securepassword')
     expect(orgRepo.createUser).toHaveBeenCalledTimes(1)
 
-    // #general created first, then the user workspace
-    expect(workspaceRepo.create).toHaveBeenCalledTimes(2)
-    expect(workspaceRepo.create).toHaveBeenCalledWith(
-      expect.objectContaining({ name: '#general' }),
-    )
-    expect(workspaceRepo.setDefault).toHaveBeenCalledTimes(1)
-    expect(orgRepo.createTeam).toHaveBeenCalledTimes(1)
-    expect(workspaceRepo.create).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'Support' }),
-    )
-    expect(tokenService.sign).toHaveBeenCalledTimes(1)
-
-    expect(result).toHaveProperty('orgId')
-    expect(result).toHaveProperty('userId')
-    expect(result.workspaceId).toBe('ws-support')
-    expect(result.token).toBe('signup-token')
-  })
-
-  it('creates only #general when no workspace name provided', async () => {
-    const { orgRepo, workspaceRepo, useCase } = setup()
-    vi.mocked(orgRepo.userExistsByEmail).mockResolvedValue(false)
-
-    const result = await useCase.execute({
-      orgName: 'Acme Corp',
-      adminName: 'Alice',
-      adminEmail: 'alice@acme.com',
-      adminPassword: 'securepassword',
-    })
-
+    // Only #general created
     expect(workspaceRepo.create).toHaveBeenCalledTimes(1)
     expect(workspaceRepo.create).toHaveBeenCalledWith(
       expect.objectContaining({ name: '#general' }),
     )
     expect(workspaceRepo.setDefault).toHaveBeenCalledTimes(1)
+    expect(tokenService.sign).toHaveBeenCalledTimes(1)
+
+    expect(result).toHaveProperty('orgId')
+    expect(result).toHaveProperty('userId')
     expect(result.workspaceId).toBe('ws-acme-corp-general')
+    expect(result.token).toBe('signup-token')
   })
 
   it('throws ConflictError if email already exists', async () => {
@@ -79,26 +53,5 @@ describe('SignupUseCase', () => {
 
     await expect(useCase.execute(validInput)).rejects.toThrow(ConflictError)
     expect(orgRepo.create).not.toHaveBeenCalled()
-  })
-
-  it('handles concurrent team creation (ER_DUP_ENTRY)', async () => {
-    const { orgRepo, workspaceRepo, useCase } = setup()
-    vi.mocked(orgRepo.userExistsByEmail).mockResolvedValue(false)
-    vi.mocked(orgRepo.findTeamByName)
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce({ id: 'existing-team-id', name: 'Engineering' })
-
-    const dupError = new Error('Duplicate entry') as Error & { code: string }
-    dupError.code = 'ER_DUP_ENTRY'
-    vi.mocked(orgRepo.createTeam).mockRejectedValue(dupError)
-
-    const result = await useCase.execute(validInput)
-
-    expect(orgRepo.findTeamByName).toHaveBeenCalledTimes(2)
-    // The user workspace (not #general) should have the team
-    expect(workspaceRepo.create).toHaveBeenCalledWith(
-      expect.objectContaining({ teamId: 'existing-team-id', name: 'Support' }),
-    )
-    expect(result).toHaveProperty('orgId')
   })
 })

--- a/src/application/auth/SignupUseCase.ts
+++ b/src/application/auth/SignupUseCase.ts
@@ -2,17 +2,15 @@ import type { OrganisationRepository } from '../../domain/organisation/repositor
 import type { WorkspaceRepository } from '../../domain/workspace/repository.js'
 import type { PasswordService } from '../ports/PasswordService.js'
 import type { TokenService } from '../ports/TokenService.js'
-import { generateId, generateSlug, generateWorkspaceId } from '../../domain/shared/EntityId.js'
+import { generateId, generateSlug } from '../../domain/shared/EntityId.js'
 import { ConflictError } from '../../domain/shared/errors.js'
+import { DEFAULT_WORKSPACE_NAME, DEFAULT_RECEPTIONIST_PROMPT } from '../../defaults.js'
 
 interface SignupInput {
   orgName: string
   adminName: string
   adminEmail: string
   adminPassword: string
-  workspaceName?: string
-  teamName?: string
-  systemPrompt?: string
 }
 
 interface SignupOutput {
@@ -51,28 +49,14 @@ export class SignupUseCase {
       id: generalId,
       orgId,
       teamId: null,
-      name: '#general',
+      name: DEFAULT_WORKSPACE_NAME,
       model: '',
-      systemPrompt: 'You are a helpful receptionist.',
+      systemPrompt: DEFAULT_RECEPTIONIST_PROMPT,
       createdBy: userId,
     })
     await this.workspaceRepo.setDefault(generalId)
 
-    // If the caller provided a workspace name, create that too
-    let userWsId = generalId
-    if (input.workspaceName) {
-      const teamId = input.teamName ? await this.resolveTeam(orgId, input.teamName) : null
-      userWsId = generateWorkspaceId(input.workspaceName)
-      await this.workspaceRepo.create({
-        id: userWsId,
-        orgId,
-        teamId,
-        name: input.workspaceName,
-        model: '',
-        systemPrompt: input.systemPrompt || 'You are a helpful assistant.',
-        createdBy: userId,
-      })
-    }
+    const userWsId = generalId
 
     const token = this.tokenService.sign({
       id: userId,
@@ -83,22 +67,5 @@ export class SignupUseCase {
     })
 
     return { orgId, userId, workspaceId: userWsId, token }
-  }
-
-  private async resolveTeam(orgId: string, teamName: string): Promise<string> {
-    const existing = await this.orgRepo.findTeamByName(orgId, teamName)
-    if (existing) return existing.id
-
-    const teamId = generateId()
-    try {
-      await this.orgRepo.createTeam(teamId, orgId, teamName)
-    } catch (err: unknown) {
-      if ((err as { code?: string }).code === 'ER_DUP_ENTRY') {
-        const retry = await this.orgRepo.findTeamByName(orgId, teamName)
-        if (retry) return retry.id
-      }
-      throw err
-    }
-    return teamId
   }
 }

--- a/src/application/conversation/LifecycleUseCase.ts
+++ b/src/application/conversation/LifecycleUseCase.ts
@@ -4,6 +4,8 @@ import type { QueueService } from '../ports/QueueService.js'
 import type { registry as ProviderRegistryType, ProviderPlugin } from '@supaproxy/providers'
 import type { ConsumerPosterRegistry, ColdMessageTarget } from '../ports/ConsumerPoster.js'
 import { generateId } from '../../domain/shared/EntityId.js'
+import { DEFAULT_COLD_MESSAGE_MAX_TOKENS, DEFAULT_STATS_ANALYSIS_MAX_TOKENS } from '../../defaults.js'
+import { buildColdMessagePrompt, DEFAULT_COLD_FALLBACK_MESSAGE, buildAnalysisPrompt } from '../../prompts.js'
 import pino from 'pino'
 
 const log = pino({ name: 'lifecycle-use-case' })
@@ -43,7 +45,7 @@ export class LifecycleUseCase {
 
   async sendColdMessage(target: ColdMessageTarget): Promise<void> {
     const message = await this.generateColdMessage(target.conversationId)
-      || "Just checking in \u2014 do you still need help with this? If not, we will close this conversation shortly."
+      || DEFAULT_COLD_FALLBACK_MESSAGE
     await this.posterRegistry.post(target, message)
   }
 
@@ -91,8 +93,8 @@ export class LifecycleUseCase {
       const analysisText = await provider.createSimpleMessage({
         apiKey,
         model,
-        maxTokens: 1024,
-        prompt: this.buildAnalysisPrompt(transcript),
+        maxTokens: DEFAULT_STATS_ANALYSIS_MAX_TOKENS,
+        prompt: buildAnalysisPrompt(transcript),
       })
 
       let text = analysisText.trim()
@@ -143,8 +145,8 @@ export class LifecycleUseCase {
       return provider.createSimpleMessage({
         apiKey,
         model,
-        maxTokens: 150,
-        prompt: `You are a support assistant. This conversation has gone quiet. Based on the conversation below, write a brief, natural follow-up message (1-2 sentences) checking in with the user. Be warm but not pushy. If it looks like the issue was resolved, acknowledge that. If not, offer to continue helping. Do not use generic corporate language. Just reply with the message text, nothing else.\n\n${transcript}`,
+        maxTokens: DEFAULT_COLD_MESSAGE_MAX_TOKENS,
+        prompt: buildColdMessagePrompt(transcript),
       })
     } catch (err) {
       log.warn({ conversationId, error: (err as Error).message }, 'Could not generate cold message')
@@ -152,26 +154,4 @@ export class LifecycleUseCase {
     }
   }
 
-  private buildAnalysisPrompt(transcript: string): string {
-    return `Analyse this conversation transcript and return ONLY a JSON object (no markdown, no explanation).
-
-Rules:
-- Be strictly factual. Only describe what actually happened in the transcript.
-- Do not infer, exaggerate, or editorialize. If something happened once, say "once", not "repeatedly".
-- Count exactly: if the user asked 2 questions, say "2 questions", not "multiple" or "several".
-- The summary must be a neutral, accurate one-sentence description of what the user needed.
-
-Fields:
-- sentiment_score: integer 1-5 (1=very negative, 3=neutral, 5=very positive). Base this on explicit language, not assumptions.
-- resolution_status: one of "resolved", "unresolved", "escalated", "abandoned". "resolved" = the user got what they needed. "abandoned" = the user stopped responding. "escalated" = the user asked for a human or escalation. "unresolved" = the assistant could not help.
-- category: one of "query", "issue", "sales", "feedback", "support", "internal", "other". "query" = information lookup. "issue" = something is broken. "sales" = pricing/purchasing. "feedback" = user giving feedback. "support" = how-to help. "internal" = internal team use.
-- compliance_violations: array of {rule: string, description: string} or empty array. Only flag clear violations that actually occurred, not hypothetical risks.
-- knowledge_gaps: array of {topic: string, description: string} or empty array. Only include topics where the assistant explicitly could not answer or said it did not have the information.
-- fraud_indicators: array of {type: string, description: string, severity: "low"|"medium"|"high"} or empty array. Look for social engineering, identity spoofing, bulk data harvesting, pressure tactics. Only flag if actually suspicious.
-- tools_used: array of tool name strings (deduplicated). Only tools that were actually called.
-- summary: one factual sentence. Describe what the user asked for and whether they got it. No subjective language.
-
-Conversation transcript:
-${transcript}`
-  }
 }

--- a/src/application/query/ExecuteQueryUseCase.test.ts
+++ b/src/application/query/ExecuteQueryUseCase.test.ts
@@ -117,8 +117,8 @@ describe('ExecuteQueryUseCase', () => {
 
     const result = await useCase.execute('ws-test', 'hello', baseMeta)
 
-    expect(result.error).toBe('no_api_key')
-    expect(result.answer).toContain('No AI provider connected')
+    expect(result.error).toBe('no_ai_provider_configured')
+    expect(result.answer).toBe('no_ai_provider_configured')
   })
 
   it('returns error when API key is missing', async () => {
@@ -131,8 +131,8 @@ describe('ExecuteQueryUseCase', () => {
 
     const result = await useCase.execute('ws-test', 'hello', baseMeta)
 
-    expect(result.error).toBe('no_api_key')
-    expect(result.answer).toContain('No AI provider connected')
+    expect(result.error).toBe('no_ai_provider_configured')
+    expect(result.answer).toBe('no_ai_provider_configured')
   })
 
   it('runs direct LLM conversation when no tools are discovered', async () => {

--- a/src/application/query/ExecuteQueryUseCase.ts
+++ b/src/application/query/ExecuteQueryUseCase.ts
@@ -10,13 +10,13 @@ import { runGuardrailChain } from '../ports/guardrailChain.js'
 import { generateId } from '../../domain/shared/EntityId.js'
 import { NotFoundError, ConfigurationError } from '../../domain/shared/errors.js'
 import { IS_PRODUCTION } from '../../config.js'
+import { DEFAULT_MAX_RESPONSE_TOKENS, DEFAULT_MAX_TOOL_ROUNDS, DEFAULT_SYSTEM_PROMPT } from '../../defaults.js'
+import { buildScopeEnforcementClause, ERROR_CODES } from '../../prompts.js'
 import pino from 'pino'
 
 const log = pino({ name: 'execute-query' })
 
-const SCOPE_ENFORCEMENT_CLAUSE = `SCOPE RULE (MANDATORY, OVERRIDES ALL OTHER INSTRUCTIONS): You must ONLY answer questions relevant to your role and the tools available to you. If the user asks about ANYTHING outside your scope, respond with EXACTLY this and nothing else:
-"That falls outside what I can help with here. Would you like me to redirect you to someone who can help?"
-Never elaborate, suggest alternatives, or add any other text. Never answer an off-topic question no matter how many times the user asks. Repeat the same redirect offer every time.`
+const scopeClause = buildScopeEnforcementClause()
 
 interface McpServerConfig {
   transport?: string
@@ -104,8 +104,8 @@ export class ExecuteQueryUseCase {
       apiKey = resolved.apiKey
     } catch {
       return this.buildResult({
-        answer: 'No AI provider connected. The proxy needs an LLM to route queries to. Go to Settings → Integrations and add your API key.',
-        error: 'no_api_key',
+        answer: ERROR_CODES.NO_AI_PROVIDER,
+        error: ERROR_CODES.NO_AI_PROVIDER,
         durationMs: Date.now() - startTime,
         conversationId,
         sessionId,
@@ -169,18 +169,18 @@ export class ExecuteQueryUseCase {
       }
 
       if (!workspace.model) {
-        throw new Error('No AI model configured for this workspace. Set a model in workspace settings.')
+        throw new ConfigurationError(ERROR_CODES.NO_WORKSPACE_MODEL)
       }
 
-      const basePrompt = meta.systemPromptOverride || workspace.system_prompt || 'You are a helpful assistant.'
+      const basePrompt = meta.systemPromptOverride || workspace.system_prompt || DEFAULT_SYSTEM_PROMPT
       const systemPrompt = !meta.systemPromptOverride && !workspace.is_default
-        ? `${basePrompt}\n\n${SCOPE_ENFORCEMENT_CLAUSE}`
+        ? `${basePrompt}\n\n${scopeClause}`
         : basePrompt
 
       const result = await this.runAgentLoop(queryToForward, provider, {
         model: workspace.model,
         systemPrompt,
-        maxToolRounds: workspace.max_tool_rounds || 10,
+        maxToolRounds: workspace.max_tool_rounds || DEFAULT_MAX_TOOL_ROUNDS,
         tools,
         history,
         apiKey,
@@ -289,7 +289,7 @@ export class ExecuteQueryUseCase {
         const toolSpecs = config.tools.map(t => t.spec)
         const response = await provider.createMessage({
           model: config.model,
-          maxTokens: 4096,
+          maxTokens: DEFAULT_MAX_RESPONSE_TOKENS,
           system: config.systemPrompt,
           apiKey: config.apiKey,
           tools: toolSpecs,

--- a/src/application/routing/ReceptionistPromptBuilder.ts
+++ b/src/application/routing/ReceptionistPromptBuilder.ts
@@ -1,37 +1,8 @@
 import type { WorkspaceRoutingSummary } from '../../domain/workspace/repository.js'
+import { buildReceptionistPrompt } from '../../prompts.js'
 
 export class ReceptionistPromptBuilder {
   build(orgName: string, workspaces: WorkspaceRoutingSummary[]): string {
-    const departmentLines = workspaces.map(ws => {
-      const toolList = ws.tool_names.length > 0
-        ? ` Tools: ${ws.tool_names.join(', ')}.`
-        : ''
-      const description = ws.system_prompt
-        ? ` ${ws.system_prompt}`
-        : ''
-      return `- ${ws.name}:${description}${toolList}`
-    })
-
-    return [
-      `You are the receptionist for ${orgName}.`,
-      '',
-      'You know about these departments:',
-      ...departmentLines,
-      '',
-      'Your job:',
-      '1. Understand what the user needs.',
-      '2. Route them to the right department.',
-      '3. If unsure, ask ONE clarifying question.',
-      '4. Never answer substantive questions yourself.',
-      '5. If the request is outside all departments, say so politely and tell them what you can help with.',
-      '6. Be warm, brief, and direct.',
-      '',
-      'When you decide to route, respond with your routing message and include the following on its own line at the end:',
-      '<!-- ROUTE:workspace_id:reason -->',
-      'Replace workspace_id with the department ID and reason with a brief explanation.',
-      '',
-      'Available department IDs:',
-      ...workspaces.map(ws => `- ${ws.id}: ${ws.name}`),
-    ].join('\n')
+    return buildReceptionistPrompt(orgName, workspaces)
   }
 }

--- a/src/application/routing/RouteMessageUseCase.ts
+++ b/src/application/routing/RouteMessageUseCase.ts
@@ -6,13 +6,11 @@ import { buildSessionKey } from '../ports/SessionStore.js'
 import type { ExecuteQueryUseCase } from '../query/ExecuteQueryUseCase.js'
 import { ReceptionistPromptBuilder } from './ReceptionistPromptBuilder.js'
 import { NotFoundError } from '../../domain/shared/errors.js'
+import { SESSION_TTL_SECONDS } from '../../defaults.js'
+import { REDIRECT_INTENT_SYSTEM, buildRedirectIntentPrompt } from '../../prompts.js'
 import pino from 'pino'
 
 const log = pino({ name: 'route-message' })
-
-const SESSION_TTL_SECONDS = 1800 // 30 minutes
-
-const REDIRECT_INTENT_PROMPT = `The user was asked: "Would you like me to redirect you to someone who can help?" They responded: "{{query}}". Do they want to be redirected?`
 
 interface RouteMessageInput {
   orgId: string
@@ -96,10 +94,10 @@ export class RouteMessageUseCase {
       const defaultWs = await this.workspaceRepo.findDefaultByOrg(orgId)
       if (!defaultWs) return false
 
-      const prompt = REDIRECT_INTENT_PROMPT.replace('{{query}}', query)
+      const prompt = buildRedirectIntentPrompt(query)
       const result = await this.executeQueryUseCase.execute(defaultWs.id, prompt, {
         consumerType: 'system',
-        systemPromptOverride: 'You are a redirect intent classifier. Answer only "yes" or "no".',
+        systemPromptOverride: REDIRECT_INTENT_SYSTEM,
         skipTools: true,
       })
       return result.answer.toLowerCase().trim().startsWith('yes')

--- a/src/application/workspace/CreateWorkspaceUseCase.ts
+++ b/src/application/workspace/CreateWorkspaceUseCase.ts
@@ -2,6 +2,7 @@ import type { OrganisationRepository } from '../../domain/organisation/repositor
 import type { WorkspaceRepository } from '../../domain/workspace/repository.js'
 import { generateId, generateWorkspaceId } from '../../domain/shared/EntityId.js'
 import { ConflictError } from '../../domain/shared/errors.js'
+import { DEFAULT_SYSTEM_PROMPT } from '../../defaults.js'
 
 interface CreateWorkspaceInput {
   name: string
@@ -33,7 +34,7 @@ export class CreateWorkspaceUseCase {
       teamId: resolvedTeamId,
       name: input.name,
       model: input.model,
-      systemPrompt: input.systemPrompt || 'You are a helpful assistant.',
+      systemPrompt: input.systemPrompt || DEFAULT_SYSTEM_PROMPT,
     })
 
     return { id: wsId, name: input.name, status: 'active' }

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,0 +1,39 @@
+/**
+ * System defaults: named constants for all configurable values.
+ *
+ * These are the fallback defaults when no workspace, org, or env
+ * override is provided. Eventually these will load from a
+ * configuration table, but for now they live here as a single
+ * source of truth (not scattered across use cases).
+ *
+ * RULE: no magic numbers or strings in use cases. Import from here.
+ */
+
+// ── Session and lifecycle ──
+
+export const SESSION_TTL_SECONDS = 1800
+export const SESSION_COOKIE_MAX_AGE = 86400
+export const DEFAULT_COLD_TIMEOUT_MINUTES = 30
+export const DEFAULT_CLOSE_TIMEOUT_MINUTES = 60
+
+// ── Agent loop ──
+
+export const DEFAULT_MAX_RESPONSE_TOKENS = 4096
+export const DEFAULT_MAX_TOOL_ROUNDS = 10
+export const DEFAULT_COLD_MESSAGE_MAX_TOKENS = 150
+export const DEFAULT_STATS_ANALYSIS_MAX_TOKENS = 1024
+
+// ── Pagination ──
+
+export const DEFAULT_PAGINATION_LIMIT = 20
+
+// ── Query validation ──
+
+export const MAX_QUERY_LENGTH = 10_000
+export const MAX_SYSTEM_PROMPT_LENGTH = 10_000
+
+// ── Workspace defaults ──
+
+export const DEFAULT_WORKSPACE_NAME = '#general'
+export const DEFAULT_SYSTEM_PROMPT = 'You are a helpful assistant.'
+export const DEFAULT_RECEPTIONIST_PROMPT = 'You are a helpful receptionist.'

--- a/src/observability/audit.test.ts
+++ b/src/observability/audit.test.ts
@@ -1,42 +1,14 @@
-import { describe, it, expect, vi, beforeAll } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 
 // Mock config to avoid env var requirements
 vi.mock('../config.js', () => ({
   LOG_DIR: '/tmp/test-logs',
 }))
 
-const { estimateCost } = await import('./audit.js')
+const { logAuditEntry } = await import('./audit.js')
 
-describe('estimateCost', () => {
-  it('returns correct cost for known model', () => {
-    const cost = estimateCost({ input: 1_000_000, output: 1_000_000 }, 'claude-sonnet-4-20250514')
-    expect(cost).toBe(18)
-  })
-
-  it('calculates fractional costs', () => {
-    const cost = estimateCost({ input: 500, output: 100 }, 'claude-sonnet-4-20250514')
-    expect(cost).toBeCloseTo(0.003)
-  })
-
-  it('returns null for unknown model', () => {
-    expect(estimateCost({ input: 1000, output: 1000 }, 'unknown-model')).toBeNull()
-  })
-
-  it('returns null when model is undefined', () => {
-    expect(estimateCost({ input: 1000, output: 1000 })).toBeNull()
-  })
-
-  it('returns 0 for zero tokens', () => {
-    expect(estimateCost({ input: 0, output: 0 }, 'gpt-4o')).toBe(0)
-  })
-
-  it('handles gpt-4o pricing', () => {
-    const cost = estimateCost({ input: 1_000_000, output: 1_000_000 }, 'gpt-4o')
-    expect(cost).toBe(12.5)
-  })
-
-  it('handles gpt-4o-mini pricing', () => {
-    const cost = estimateCost({ input: 1_000_000, output: 1_000_000 }, 'gpt-4o-mini')
-    expect(cost).toBeCloseTo(0.75)
+describe('logAuditEntry', () => {
+  it('is exported as a function', () => {
+    expect(typeof logAuditEntry).toBe('function')
   })
 })

--- a/src/observability/audit.ts
+++ b/src/observability/audit.ts
@@ -25,18 +25,3 @@ export function logAuditEntry(entry: AuditEntry): void {
     log.error({ error: (err as Error).message }, 'Failed to write audit log')
   }
 }
-
-/** Per-million-token pricing by model. Add entries as needed. */
-const MODEL_PRICING: Record<string, { input: number; output: number }> = {
-  'claude-sonnet-4-20250514': { input: 3, output: 15 },
-  'claude-haiku-4-5-20251001': { input: 0.80, output: 4 },
-  'gpt-4o': { input: 2.50, output: 10 },
-  'gpt-4o-mini': { input: 0.15, output: 0.60 },
-}
-
-/** Estimate cost based on token usage and model. Returns null if pricing is unknown. */
-export function estimateCost(tokens: { input: number; output: number }, model?: string): number | null {
-  const pricing = model ? MODEL_PRICING[model] : undefined
-  if (!pricing) return null
-  return (tokens.input * pricing.input + tokens.output * pricing.output) / 1_000_000
-}

--- a/src/presentation/routes/auth.ts
+++ b/src/presentation/routes/auth.ts
@@ -7,18 +7,15 @@ import type { LoginUseCase } from '../../application/auth/LoginUseCase.js'
 import type { TokenService } from '../../application/ports/TokenService.js'
 import { parseBody } from '../middleware/validate.js'
 import { ConflictError, AuthenticationError } from '../../domain/shared/errors.js'
+import { SESSION_COOKIE_MAX_AGE } from '../../defaults.js'
 
 const log = pino({ name: 'routes/auth' })
-const SESSION_MAX_AGE = 86400
 
 const signupSchema = z.object({
   org_name: z.string().min(1, 'Organisation name is required').max(255),
   admin_name: z.string().min(1, 'Admin name is required').max(255),
   admin_email: z.string().email('A valid email is required').max(255),
   admin_password: z.string().min(8, 'Password must be at least 8 characters').max(255),
-  workspace_name: z.string().max(255).optional(),
-  team_name: z.string().max(255).optional(),
-  system_prompt: z.string().max(10000).optional(),
 })
 
 const loginSchema = z.object({
@@ -48,9 +45,6 @@ export function createAuthRoutes(deps: AuthRouteDeps) {
         adminName: result.data.admin_name,
         adminEmail: result.data.admin_email,
         adminPassword: result.data.admin_password,
-        workspaceName: result.data.workspace_name,
-        teamName: result.data.team_name,
-        systemPrompt: result.data.system_prompt,
       })
 
       setCookie(c, 'supaproxy_session', output.token, {
@@ -58,7 +52,7 @@ export function createAuthRoutes(deps: AuthRouteDeps) {
         secure: deps.isProduction,
         sameSite: 'Lax',
         path: '/',
-        maxAge: SESSION_MAX_AGE,
+        maxAge: SESSION_COOKIE_MAX_AGE,
         ...(deps.cookieDomain && { domain: deps.cookieDomain }),
       })
 
@@ -101,7 +95,7 @@ export function createAuthRoutes(deps: AuthRouteDeps) {
         secure: deps.isProduction,
         sameSite: 'Lax',
         path: '/',
-        maxAge: SESSION_MAX_AGE,
+        maxAge: SESSION_COOKIE_MAX_AGE,
         ...(deps.cookieDomain && { domain: deps.cookieDomain }),
       })
 

--- a/src/presentation/routes/query.ts
+++ b/src/presentation/routes/query.ts
@@ -2,13 +2,14 @@ import { Hono } from 'hono'
 import { z } from 'zod'
 import type { ExecuteQueryUseCase } from '../../application/query/ExecuteQueryUseCase.js'
 import { parseBody } from '../middleware/validate.js'
+import { MAX_QUERY_LENGTH } from '../../defaults.js'
 import { type AuthUser, type AuthEnv } from '../middleware/auth.js'
 import type { WorkspaceRepository } from '../../domain/workspace/repository.js'
 import type { TenantService } from '../../application/ports/TenantService.js'
 import { NotFoundError } from '../../domain/shared/errors.js'
 
 const queryBodySchema = z.object({
-  query: z.string().min(1, 'Query is required').max(10000),
+  query: z.string().min(1, 'Query is required').max(MAX_QUERY_LENGTH),
   session_id: z.string().max(255).optional(),
   consumer_type: z.string().max(50).optional(),
   consumer_context: z.object({

--- a/src/presentation/routes/route.ts
+++ b/src/presentation/routes/route.ts
@@ -2,11 +2,12 @@ import { Hono } from 'hono'
 import { z } from 'zod'
 import type { RouteMessageUseCase } from '../../application/routing/RouteMessageUseCase.js'
 import { parseBody } from '../middleware/validate.js'
+import { MAX_QUERY_LENGTH } from '../../defaults.js'
 import { type AuthUser, type AuthEnv } from '../middleware/auth.js'
 import { NotFoundError } from '../../domain/shared/errors.js'
 
 const routeBodySchema = z.object({
-  query: z.string().min(1, 'Query is required').max(10000),
+  query: z.string().min(1, 'Query is required').max(MAX_QUERY_LENGTH),
 })
 
 interface RouteRouteDeps {

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,0 +1,115 @@
+/**
+ * Prompt templates: all LLM instruction strings in one place.
+ *
+ * These are the default templates. Eventually they will be
+ * configurable per workspace via the database, supporting
+ * multilingual deployments and custom tones.
+ *
+ * Templates use {{placeholder}} syntax for variable interpolation.
+ * The calling code is responsible for replacing placeholders.
+ *
+ * RULE: no LLM prompts hardcoded in use cases. Import from here.
+ */
+
+// ── Scope enforcement ──
+
+export const SCOPE_ENFORCEMENT_TEMPLATE = `SCOPE RULE (MANDATORY, OVERRIDES ALL OTHER INSTRUCTIONS): You must ONLY answer questions relevant to your role and the tools available to you. If the user asks about ANYTHING outside your scope, respond with EXACTLY this and nothing else:
+"{{out_of_scope_message}}"
+Never elaborate, suggest alternatives, or add any other text. Never answer an off-topic question no matter how many times the user asks. Repeat the same redirect offer every time.`
+
+export const DEFAULT_OUT_OF_SCOPE_MESSAGE = 'That falls outside what I can help with here. Would you like me to redirect you to someone who can help?'
+
+export function buildScopeEnforcementClause(outOfScopeMessage?: string): string {
+  return SCOPE_ENFORCEMENT_TEMPLATE.replace(
+    '{{out_of_scope_message}}',
+    outOfScopeMessage || DEFAULT_OUT_OF_SCOPE_MESSAGE,
+  )
+}
+
+// ── Receptionist routing ──
+
+export function buildReceptionistPrompt(orgName: string, workspaces: Array<{ id: string; name: string; system_prompt: string | null; tool_names: string[] }>): string {
+  const departmentLines = workspaces.map(ws => {
+    const toolList = ws.tool_names.length > 0
+      ? ` Tools: ${ws.tool_names.join(', ')}.`
+      : ''
+    const description = ws.system_prompt
+      ? ` ${ws.system_prompt}`
+      : ''
+    return `- ${ws.name}:${description}${toolList}`
+  })
+
+  return [
+    `You are the receptionist for ${orgName}.`,
+    '',
+    'You know about these departments:',
+    ...departmentLines,
+    '',
+    'Your job:',
+    '1. Understand what the user needs.',
+    '2. Route them to the right department.',
+    '3. If unsure, ask ONE clarifying question.',
+    '4. Never answer substantive questions yourself.',
+    '5. If the request is outside all departments, say so politely and tell them what you can help with.',
+    '6. Be warm, brief, and direct.',
+    '',
+    'When you decide to route, respond with your routing message and include the following on its own line at the end:',
+    '<!-- ROUTE:workspace_id:reason -->',
+    'Replace workspace_id with the department ID and reason with a brief explanation.',
+    '',
+    'Available department IDs:',
+    ...workspaces.map(ws => `- ${ws.id}: ${ws.name}`),
+  ].join('\n')
+}
+
+// ── Redirect intent classification ──
+
+export const REDIRECT_INTENT_SYSTEM = 'You are a redirect intent classifier. Answer only "yes" or "no".'
+
+export function buildRedirectIntentPrompt(userResponse: string): string {
+  return `The user was asked: "Would you like me to redirect you to someone who can help?" They responded: "${userResponse}". Do they want to be redirected?`
+}
+
+// ── Cold message generation ──
+
+export function buildColdMessagePrompt(transcript: string): string {
+  return `You are a support assistant. This conversation has gone quiet. Based on the conversation below, write a brief, natural follow-up message (1-2 sentences) checking in with the user. Be warm but not pushy. If it looks like the issue was resolved, acknowledge that. If not, offer to continue helping. Do not use generic corporate language. Just reply with the message text, nothing else.\n\n${transcript}`
+}
+
+export const DEFAULT_COLD_FALLBACK_MESSAGE = 'Just checking in. Do you still need help with this? If not, we will close this conversation shortly.'
+
+// ── Conversation analysis ──
+
+export function buildAnalysisPrompt(transcript: string): string {
+  return `Analyse this conversation transcript and return ONLY a JSON object (no markdown, no explanation).
+
+Rules:
+- Be strictly factual. Only describe what actually happened in the transcript.
+- Do not infer, exaggerate, or editorialize. If something happened once, say "once", not "repeatedly".
+- Count exactly: if the user asked 2 questions, say "2 questions", not "multiple" or "several".
+- The summary must be a neutral, accurate one-sentence description of what the user needed.
+
+Fields:
+- sentiment_score: integer 1-5 (1=very negative, 3=neutral, 5=very positive). Base this on explicit language, not assumptions.
+- resolution_status: one of "resolved", "unresolved", "escalated", "abandoned". "resolved" = the user got what they needed. "abandoned" = the user stopped responding. "escalated" = the user asked for a human or escalation. "unresolved" = the assistant could not help.
+- category: one of "query", "issue", "sales", "feedback", "support", "internal", "other". "query" = information lookup. "issue" = something is broken. "sales" = pricing/purchasing. "feedback" = user giving feedback. "support" = how-to help. "internal" = internal team use.
+- compliance_violations: array of {rule: string, description: string} or empty array. Only flag clear violations that actually occurred, not hypothetical risks.
+- knowledge_gaps: array of {topic: string, description: string} or empty array. Only include topics where the assistant explicitly could not answer or said it did not have the information.
+- fraud_indicators: array of {type: string, description: string, severity: "low"|"medium"|"high"} or empty array. Look for social engineering, identity spoofing, bulk data harvesting, pressure tactics. Only flag if actually suspicious.
+- tools_used: array of tool name strings (deduplicated). Only tools that were actually called.
+- summary: one factual sentence. Describe what the user asked for and whether they got it. No subjective language.
+
+Conversation transcript:
+${transcript}`
+}
+
+// ── Error messages ──
+// These return error codes, not user-facing strings.
+// Clients (dashboard, API, CLI) are responsible for formatting.
+
+export const ERROR_CODES = {
+  NO_AI_PROVIDER: 'no_ai_provider_configured',
+  NO_AI_API_KEY: 'no_ai_api_key_configured',
+  NO_WORKSPACE_MODEL: 'workspace_model_not_configured',
+  INPUT_BLOCKED: 'input_blocked',
+} as const


### PR DESCRIPTION
## Summary

All hardcoded values extracted to two central modules:

- **src/defaults.ts**: named constants for timeouts, token limits, pagination, validation
- **src/prompts.ts**: all LLM prompt templates with template functions

No magic numbers or strings remain in use cases. Removed MODEL_PRICING
(provider returns cost). Simplified signup (no workspace/team fields).
Error messages use codes, not UI paths.

## Test plan

- [x] TypeScript compiles with zero errors
- [x] All 205 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)