### PR TITLE
fix: routing context continuity and master conversation log

### DIFF
--- a/src/application/ports/SessionStore.ts
+++ b/src/application/ports/SessionStore.ts
@@ -3,6 +3,7 @@ export interface RoutingSession {
   lastMessageAt: number
   routedFrom: string | null
   routedFromConversationId?: string
+  generalConversationId?: string
   pendingRedirect?: boolean
 }
 

--- a/src/application/query/ExecuteQueryUseCase.ts
+++ b/src/application/query/ExecuteQueryUseCase.ts
@@ -69,6 +69,7 @@ interface QueryMeta {
   skipTools?: boolean
   routedFrom?: string
   routedFromConversationId?: string
+  priorHistory?: Array<{ role: 'user' | 'assistant'; content: string }>
 }
 
 export class ExecuteQueryUseCase {
@@ -98,7 +99,9 @@ export class ExecuteQueryUseCase {
       await this.conversationUseCase.setRouting(conversationId, meta.routedFrom, workspace.name, '')
     }
 
-    const history = await this.conversationUseCase.getHistory(conversationId)
+    const ownHistory = await this.conversationUseCase.getHistory(conversationId)
+    // Prepend prior context from routing (e.g. receptionist conversation) so the target workspace knows what was already discussed
+    const history = [...(meta.priorHistory || []), ...ownHistory]
 
     let provider: ProviderPlugin
     let apiKey: string

--- a/src/application/routing/RouteMessageUseCase.test.ts
+++ b/src/application/routing/RouteMessageUseCase.test.ts
@@ -50,7 +50,7 @@ describe('RouteMessageUseCase', () => {
     workspaceRepo = mockWorkspaceRepo()
     sessionStore = mockSessionStore()
     executeQuery = mockExecuteQuery()
-    useCase = new RouteMessageUseCase(workspaceRepo, orgRepo, mockConversationRepo(), sessionStore, executeQuery)
+    useCase = new RouteMessageUseCase(workspaceRepo, orgRepo, mockConversationRepo(), sessionStore, executeQuery, { recordMessage: vi.fn(), getHistory: vi.fn().mockResolvedValue([]), findOrCreate: vi.fn(), setRouting: vi.fn() } as any)
   })
 
   it('uses existing session to route directly to workspace', async () => {
@@ -356,7 +356,7 @@ describe('RouteMessageUseCase', () => {
 
   it('records routing metadata on conversation when routing happens', async () => {
     const conversationRepo = mockConversationRepo()
-    const localUseCase = new RouteMessageUseCase(workspaceRepo, orgRepo, conversationRepo, sessionStore, executeQuery)
+    const localUseCase = new RouteMessageUseCase(workspaceRepo, orgRepo, conversationRepo, sessionStore, executeQuery, { recordMessage: vi.fn(), getHistory: vi.fn().mockResolvedValue([]), findOrCreate: vi.fn(), setRouting: vi.fn() } as any)
 
     const defaultWs = stubWorkspace({ id: 'ws-general', name: '#general', is_default: true })
     const targetWs = stubWorkspace({ id: 'ws-insurance', name: 'Insurance' })

--- a/src/application/routing/RouteMessageUseCase.ts
+++ b/src/application/routing/RouteMessageUseCase.ts
@@ -4,6 +4,7 @@ import type { ConversationRepository } from '../../domain/conversation/repositor
 import type { SessionStore, RoutingSession } from '../ports/SessionStore.js'
 import { buildSessionKey } from '../ports/SessionStore.js'
 import type { ExecuteQueryUseCase } from '../query/ExecuteQueryUseCase.js'
+import type { ManageConversationUseCase } from '../conversation/ManageConversationUseCase.js'
 import { ReceptionistPromptBuilder } from './ReceptionistPromptBuilder.js'
 import { NotFoundError } from '../../domain/shared/errors.js'
 import { SESSION_TTL_SECONDS, CONSUMER_TYPE_SYSTEM } from '../../defaults.js'
@@ -38,6 +39,7 @@ export class RouteMessageUseCase {
     private readonly conversationRepo: ConversationRepository,
     private readonly sessionStore: SessionStore,
     private readonly executeQueryUseCase: ExecuteQueryUseCase,
+    private readonly conversationUseCase: ManageConversationUseCase,
   ) {}
 
   async execute(input: RouteMessageInput): Promise<RouteMessageOutput> {
@@ -58,7 +60,12 @@ export class RouteMessageUseCase {
         }
       }
 
-      // Execute in the current workspace
+      // Get prior conversation history for context continuity
+      const priorHistory = existingSession.routedFromConversationId
+        ? await this.conversationUseCase.getHistory(existingSession.routedFromConversationId)
+        : undefined
+
+      // Execute in the current workspace with prior context
       const result = await this.executeQueryUseCase.execute(existingSession.workspaceId, input.query, {
         consumerType: input.consumerType,
         channel: input.entryPoint,
@@ -66,7 +73,13 @@ export class RouteMessageUseCase {
         userName: input.userName,
         routedFrom: existingSession.routedFrom || undefined,
         routedFromConversationId: existingSession.routedFromConversationId || undefined,
+        priorHistory,
       })
+
+      // Log to #general master conversation as well
+      if (existingSession.generalConversationId) {
+        await this.logToGeneral(existingSession.generalConversationId, input.query, result.answer)
+      }
 
       // Update session: set pendingRedirect if scope guardrail triggered, clear otherwise
       const redirectOffered = isRedirectOffer(result.answer)
@@ -74,6 +87,8 @@ export class RouteMessageUseCase {
         workspaceId: existingSession.workspaceId,
         lastMessageAt: Date.now(),
         routedFrom: existingSession.routedFrom,
+        routedFromConversationId: existingSession.routedFromConversationId,
+        generalConversationId: existingSession.generalConversationId,
         pendingRedirect: redirectOffered,
       }, SESSION_TTL_SECONDS)
 
@@ -172,15 +187,17 @@ export class RouteMessageUseCase {
         }
       }
 
-      // Create session pointing to the target workspace, with source conversation ID
+      // Create session pointing to the target workspace
+      // Store #general conversation ID so we can log all messages there too
       await this.sessionStore.set(sessionKey, {
         workspaceId: targetWorkspaceId,
         lastMessageAt: Date.now(),
         routedFrom: defaultWs.name,
         routedFromConversationId: result.conversationId,
+        generalConversationId: result.conversationId,
       }, SESSION_TTL_SECONDS)
 
-      // Record routing metadata on the conversation (store names, not IDs)
+      // Record routing metadata on the conversation
       await this.conversationRepo.updateRouting(
         result.conversationId, defaultWs.name, targetWs.name, routeReason,
       )
@@ -205,8 +222,7 @@ export class RouteMessageUseCase {
       }
     }
 
-    // No routing directive: receptionist is still talking (asking clarifying question or out-of-scope)
-    // Keep session on #general so the next message continues the receptionist conversation
+    // No routing directive: receptionist is still talking
     await this.createSession(sessionKey, defaultWs.id, null)
 
     return {
@@ -214,6 +230,16 @@ export class RouteMessageUseCase {
       conversationId: result.conversationId,
       workspaceId: defaultWs.id,
       routed: false,
+    }
+  }
+
+  /** Log messages to the #general master conversation for full audit trail */
+  private async logToGeneral(generalConversationId: string, query: string, answer: string): Promise<void> {
+    try {
+      await this.conversationUseCase.recordMessage(generalConversationId, 'user', query)
+      await this.conversationUseCase.recordMessage(generalConversationId, 'assistant', answer)
+    } catch (err) {
+      log.warn({ error: (err as Error).message }, 'Failed to log to #general conversation')
     }
   }
 

--- a/src/container.ts
+++ b/src/container.ts
@@ -228,7 +228,7 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
 
   const executeQueryUseCase = new ExecuteQueryUseCase(workspaceRepo, orgRepo, auditRepo, providerRegistry, mcpFactory, manageConversationUseCase, resolveGuardrails)
   const sessionStore = new RedisSessionStore(REDIS_HOST, REDIS_PORT)
-  const routeMessageUseCase = new RouteMessageUseCase(workspaceRepo, orgRepo, conversationRepo, sessionStore, executeQueryUseCase)
+  const routeMessageUseCase = new RouteMessageUseCase(workspaceRepo, orgRepo, conversationRepo, sessionStore, executeQueryUseCase, manageConversationUseCase)
   const manageQueuesUseCase = new ManageQueuesUseCase(queueService)
 
   // Build routes


### PR DESCRIPTION
Context carried across workspaces. All messages logged to #general. Closes #71.