### PR TITLE
fix: random workspace IDs, no cross-org collisions

### DIFF
--- a/src/application/auth/SignupUseCase.test.ts
+++ b/src/application/auth/SignupUseCase.test.ts
@@ -43,7 +43,7 @@ describe('SignupUseCase', () => {
 
     expect(result).toHaveProperty('orgId')
     expect(result).toHaveProperty('userId')
-    expect(result.workspaceId).toBe('ws-acme-corp-general')
+    expect(result.workspaceId).toMatch(/^ws-[0-9a-f]{24}$/)
     expect(result.token).toBe('signup-token')
   })
 

--- a/src/application/auth/SignupUseCase.ts
+++ b/src/application/auth/SignupUseCase.ts
@@ -2,7 +2,7 @@ import type { OrganisationRepository } from '../../domain/organisation/repositor
 import type { WorkspaceRepository } from '../../domain/workspace/repository.js'
 import type { PasswordService } from '../ports/PasswordService.js'
 import type { TokenService } from '../ports/TokenService.js'
-import { generateId, generateSlug } from '../../domain/shared/EntityId.js'
+import { generateId, generateSlug, generateWorkspaceId } from '../../domain/shared/EntityId.js'
 import { ConflictError } from '../../domain/shared/errors.js'
 import { DEFAULT_WORKSPACE_NAME, DEFAULT_RECEPTIONIST_PROMPT } from '../../defaults.js'
 
@@ -44,7 +44,7 @@ export class SignupUseCase {
     await this.orgRepo.createUser(userId, orgId, input.adminEmail, input.adminName, hash, 'admin')
 
     // Auto-create the #general default workspace (receptionist)
-    const generalId = `ws-${slug}-general`
+    const generalId = generateWorkspaceId()
     await this.workspaceRepo.create({
       id: generalId,
       orgId,

--- a/src/application/workspace/CreateWorkspaceUseCase.test.ts
+++ b/src/application/workspace/CreateWorkspaceUseCase.test.ts
@@ -1,37 +1,42 @@
 import { describe, it, expect, vi } from 'vitest'
 import { mockWorkspaceRepo, mockOrgRepo } from '../../__tests__/mocks.js'
 import { CreateWorkspaceUseCase } from './CreateWorkspaceUseCase.js'
-import { ConflictError } from '../../domain/shared/errors.js'
 
 describe('CreateWorkspaceUseCase', () => {
-  it('creates workspace with team ID', async () => {
+  it('creates workspace with random ID (org-safe)', async () => {
     const wsRepo = mockWorkspaceRepo()
     const orgRepo = mockOrgRepo()
     const uc = new CreateWorkspaceUseCase(wsRepo, orgRepo)
 
     const result = await uc.execute({
       name: 'My Workspace',
-      model: 'claude-sonnet-4-20250514',
+      model: 'test-model',
       teamId: 'team-1',
       orgId: 'org-1',
     })
 
-    expect(result).toEqual({
-      id: 'ws-my-workspace',
-      name: 'My Workspace',
-      status: 'active',
-    })
-    expect(wsRepo.existsById).toHaveBeenCalledWith('ws-my-workspace')
+    expect(result.id).toMatch(/^ws-[0-9a-f]{24}$/)
+    expect(result.name).toBe('My Workspace')
+    expect(result.status).toBe('active')
     expect(wsRepo.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        id: 'ws-my-workspace',
+        id: expect.stringMatching(/^ws-/),
         orgId: 'org-1',
         teamId: 'team-1',
         name: 'My Workspace',
-        model: 'claude-sonnet-4-20250514',
       }),
     )
-    expect(orgRepo.findTeamByName).not.toHaveBeenCalled()
+  })
+
+  it('two workspaces with the same name get different IDs', async () => {
+    const wsRepo = mockWorkspaceRepo()
+    const orgRepo = mockOrgRepo()
+    const uc = new CreateWorkspaceUseCase(wsRepo, orgRepo)
+
+    const result1 = await uc.execute({ name: 'Insurance', model: 'test-model', orgId: 'org-1' })
+    const result2 = await uc.execute({ name: 'Insurance', model: 'test-model', orgId: 'org-2' })
+
+    expect(result1.id).not.toBe(result2.id)
   })
 
   it('creates workspace with new team name', async () => {
@@ -39,59 +44,35 @@ describe('CreateWorkspaceUseCase', () => {
     const orgRepo = mockOrgRepo()
     const uc = new CreateWorkspaceUseCase(wsRepo, orgRepo)
 
-    // findTeamByName returns null so a new team is created
     vi.mocked(orgRepo.findTeamByName).mockResolvedValue(null)
 
     const result = await uc.execute({
       name: 'Support Bot',
-      model: 'claude-sonnet-4-20250514',
+      model: 'test-model',
       teamName: 'Support Team',
       orgId: 'org-1',
     })
 
-    expect(result.id).toBe('ws-support-bot')
+    expect(result.id).toMatch(/^ws-/)
     expect(orgRepo.findTeamByName).toHaveBeenCalledWith('org-1', 'Support Team')
-    expect(orgRepo.createTeam).toHaveBeenCalledWith(
-      expect.any(String),
-      'org-1',
-      'Support Team',
-    )
-    expect(wsRepo.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        teamId: expect.any(String),
-      }),
-    )
+    expect(orgRepo.createTeam).toHaveBeenCalledWith(expect.any(String), 'org-1', 'Support Team')
   })
 
-  it('throws ConflictError if workspace already exists', async () => {
+  it('uses existing team when teamId provided', async () => {
     const wsRepo = mockWorkspaceRepo()
     const orgRepo = mockOrgRepo()
     const uc = new CreateWorkspaceUseCase(wsRepo, orgRepo)
 
-    vi.mocked(wsRepo.existsById).mockResolvedValue(true)
-
-    await expect(
-      uc.execute({
-        name: 'Existing',
-        model: 'claude-sonnet-4-20250514',
-        orgId: 'org-1',
-      }),
-    ).rejects.toThrow(ConflictError)
-
-    expect(wsRepo.create).not.toHaveBeenCalled()
-  })
-
-  it('generates workspace ID from name', async () => {
-    const wsRepo = mockWorkspaceRepo()
-    const orgRepo = mockOrgRepo()
-    const uc = new CreateWorkspaceUseCase(wsRepo, orgRepo)
-
-    const result = await uc.execute({
-      name: 'Hello World 123',
-      model: 'claude-sonnet-4-20250514',
+    await uc.execute({
+      name: 'Test',
+      model: 'test-model',
+      teamId: 'team-existing',
       orgId: 'org-1',
     })
 
-    expect(result.id).toBe('ws-hello-world-123')
+    expect(orgRepo.findTeamByName).not.toHaveBeenCalled()
+    expect(wsRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ teamId: 'team-existing' }),
+    )
   })
 })

--- a/src/application/workspace/CreateWorkspaceUseCase.ts
+++ b/src/application/workspace/CreateWorkspaceUseCase.ts
@@ -1,7 +1,6 @@
 import type { OrganisationRepository } from '../../domain/organisation/repository.js'
 import type { WorkspaceRepository } from '../../domain/workspace/repository.js'
 import { generateId, generateWorkspaceId } from '../../domain/shared/EntityId.js'
-import { ConflictError } from '../../domain/shared/errors.js'
 import { DEFAULT_SYSTEM_PROMPT } from '../../defaults.js'
 
 interface CreateWorkspaceInput {
@@ -21,12 +20,7 @@ export class CreateWorkspaceUseCase {
 
   async execute(input: CreateWorkspaceInput): Promise<{ id: string; name: string; status: string }> {
     const resolvedTeamId = await this.resolveTeam(input.orgId, input.teamId, input.teamName)
-    const wsId = generateWorkspaceId(input.name)
-
-    const exists = await this.workspaceRepo.existsById(wsId)
-    if (exists) {
-      throw new ConflictError('A workspace with this name already exists.')
-    }
+    const wsId = generateWorkspaceId()
 
     await this.workspaceRepo.create({
       id: wsId,

--- a/src/domain/shared/EntityId.test.ts
+++ b/src/domain/shared/EntityId.test.ts
@@ -46,11 +46,20 @@ describe('generateSlug', () => {
 })
 
 describe('generateWorkspaceId', () => {
-  it('prefixes the slug with "ws-"', () => {
-    expect(generateWorkspaceId('Acme Corp')).toBe('ws-acme-corp')
+  it('returns a ws- prefixed random hex string', () => {
+    const id = generateWorkspaceId()
+    expect(id).toMatch(/^ws-[0-9a-f]{24}$/)
   })
 
-  it('applies slug rules to the name', () => {
-    expect(generateWorkspaceId('  My Workspace!  ')).toBe('ws-my-workspace')
+  it('returns unique values (no collision between orgs)', () => {
+    const ids = new Set(Array.from({ length: 100 }, () => generateWorkspaceId()))
+    expect(ids.size).toBe(100)
+  })
+
+  it('different orgs creating same workspace name get different IDs', () => {
+    // This was the bug: generateWorkspaceId('Insurance') always returned ws-insurance
+    const id1 = generateWorkspaceId()
+    const id2 = generateWorkspaceId()
+    expect(id1).not.toBe(id2)
   })
 })

--- a/src/domain/shared/EntityId.ts
+++ b/src/domain/shared/EntityId.ts
@@ -12,6 +12,6 @@ export function generateSlug(name: string): string {
     .replace(/^-|-$/g, '')
 }
 
-export function generateWorkspaceId(name: string): string {
-  return `ws-${generateSlug(name)}`
+export function generateWorkspaceId(): string {
+  return `ws-${randomBytes(12).toString('hex')}`
 }


### PR DESCRIPTION
generateWorkspaceId() returns random hex. Two orgs can have same workspace name. 206 tests pass.