### PR TITLE
feat: store guardrail events and surface in compliance API (#83)

### DIFF
--- a/src/__tests__/mocks.ts
+++ b/src/__tests__/mocks.ts
@@ -12,6 +12,7 @@ import type { AIProvider } from '../application/ports/AIProvider.js'
 import type { ModelRepository } from '../application/ports/ModelRepository.js'
 import type { ConsumerPosterRegistry } from '../application/ports/ConsumerPoster.js'
 import type { PromptTemplateRepository } from '../domain/prompt/repository.js'
+import type { GuardrailEventRepository } from '../domain/guardrail/repository.js'
 
 // ── Stub data ──
 
@@ -263,5 +264,12 @@ export function mockPosterRegistry(): ConsumerPosterRegistry {
   return {
     register: vi.fn(),
     post: vi.fn().mockResolvedValue(true),
+  }
+}
+
+export function mockGuardrailEventRepo(): GuardrailEventRepository {
+  return {
+    create: vi.fn().mockResolvedValue(undefined),
+    findByWorkspace: vi.fn().mockResolvedValue([]),
   }
 }

--- a/src/application/query/ExecuteQueryUseCase.ts
+++ b/src/application/query/ExecuteQueryUseCase.ts
@@ -6,6 +6,7 @@ import type { registry as ProviderRegistryType } from '@supaproxy/providers'
 import type { GuardrailPlugin } from '@supaproxy/guardrails'
 import type { ExecutionRailRegistry } from '@supaproxy/guardrails'
 import type { RetrievalRailRegistry } from '@supaproxy/guardrails'
+import type { GuardrailEventRepository, GuardrailEventData } from '../../domain/guardrail/repository.js'
 import type { McpClientFactory, McpConnection } from '../ports/McpClient.js'
 import type { ManageConversationUseCase } from '../conversation/ManageConversationUseCase.js'
 import { runGuardrailChain } from '../ports/guardrailChain.js'
@@ -87,6 +88,7 @@ export class ExecuteQueryUseCase {
     private readonly promptResolver?: PromptResolver,
     private readonly executionRails?: ExecutionRailRegistry,
     private readonly retrievalRails?: RetrievalRailRegistry,
+    private readonly guardrailEventRepo?: GuardrailEventRepository,
   ) {}
 
   async execute(workspaceId: string, query: string, meta: QueryMeta): Promise<QueryResult> {
@@ -202,6 +204,7 @@ export class ExecuteQueryUseCase {
         history,
         apiKey,
         workspaceId,
+        conversationId,
       })
 
       result.durationMs = Date.now() - startTime
@@ -295,6 +298,7 @@ export class ExecuteQueryUseCase {
     history: Array<{ role: 'user' | 'assistant'; content: string }>
     apiKey: string
     workspaceId: string
+    conversationId: string
   }): Promise<{ answer: string; toolsCalled: ToolCallRecord[]; connectionsHit: string[]; tokensInput: number; tokensOutput: number; costUsd: number; durationMs: number; error: string | null }> {
     const result = { answer: '', toolsCalled: [] as ToolCallRecord[], connectionsHit: [] as string[], tokensInput: 0, tokensOutput: 0, costUsd: 0, durationMs: 0, error: null as string | null }
 
@@ -354,6 +358,11 @@ export class ExecuteQueryUseCase {
             if (!railResult.allowed) {
               log.info({ tool: tu.name, reason: railResult.reason }, 'Tool call blocked by execution rail')
               toolResults.push({ type: 'tool_result', id: tu.id, text: `Tool call blocked: ${railResult.reason}` })
+              this.writeGuardrailEvent({
+                id: generateId(), workspace_id: config.workspaceId, conversation_id: config.conversationId,
+                event_type: 'execution_blocked', plugin_id: 'write-guard',
+                tool_name: tu.name!, original_query: query, reason: railResult.reason || null, stripped_content: null,
+              })
               continue
             }
           }
@@ -368,6 +377,14 @@ export class ExecuteQueryUseCase {
             // Retrieval rail: sanitise tool output before feeding back to LLM
             if (this.retrievalRails) {
               const sanitised = await this.retrievalRails.sanitise(resultText)
+              if (sanitised.stripped.length > 0) {
+                this.writeGuardrailEvent({
+                  id: generateId(), workspace_id: config.workspaceId, conversation_id: config.conversationId,
+                  event_type: 'retrieval_stripped', plugin_id: 'injection-sanitiser',
+                  tool_name: tu.name!, original_query: null, reason: null,
+                  stripped_content: sanitised.stripped.join(', ').substring(0, 500),
+                })
+              }
               resultText = sanitised.content
             }
 
@@ -435,6 +452,13 @@ export class ExecuteQueryUseCase {
     } catch (err) {
       log.error({ error: (err as Error).message }, 'Failed to write audit log')
     }
+  }
+
+  private writeGuardrailEvent(data: GuardrailEventData): void {
+    if (!this.guardrailEventRepo) return
+    this.guardrailEventRepo.create(data).catch(err => {
+      log.error({ error: (err as Error).message }, 'Failed to write guardrail event')
+    })
   }
 
   private async recordMessages(conversationId: string, query: string, answer: string, auditLogId: string): Promise<void> {

--- a/src/application/workspace/GetComplianceUseCase.test.ts
+++ b/src/application/workspace/GetComplianceUseCase.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { mockWorkspaceRepo, mockConversationRepo } from '../../__tests__/mocks.js'
+import { mockWorkspaceRepo, mockConversationRepo, mockGuardrailEventRepo } from '../../__tests__/mocks.js'
 import { GetComplianceUseCase } from './GetComplianceUseCase.js'
 
 describe('GetComplianceUseCase', () => {
@@ -33,5 +33,34 @@ describe('GetComplianceUseCase', () => {
     const result = await useCase.execute('ws-test')
 
     expect(result.violations).toHaveLength(0)
+  })
+
+  it('includes guardrail events in the response', async () => {
+    const wsRepo = mockWorkspaceRepo()
+    const convRepo = mockConversationRepo()
+    const eventRepo = mockGuardrailEventRepo()
+    vi.mocked(eventRepo.findByWorkspace).mockResolvedValue([
+      { id: 'evt-1', workspace_id: 'ws-test', conversation_id: 'conv-1', event_type: 'execution_blocked', plugin_id: 'write-guard', tool_name: 'delete_account', original_query: 'What is my balance?', reason: 'No write intent', stripped_content: null, created_at: '2026-05-13' },
+      { id: 'evt-2', workspace_id: 'ws-test', conversation_id: 'conv-2', event_type: 'retrieval_stripped', plugin_id: 'injection-sanitiser', tool_name: 'fetch_page', original_query: null, reason: null, stripped_content: 'Ignore previous instructions', created_at: '2026-05-13' },
+    ])
+
+    const useCase = new GetComplianceUseCase(wsRepo, convRepo, eventRepo)
+    const result = await useCase.execute('ws-test')
+
+    expect(result.guardrailEvents).toHaveLength(2)
+    expect(result.guardrailEvents[0].event_type).toBe('execution_blocked')
+    expect(result.guardrailEvents[0].tool_name).toBe('delete_account')
+    expect(result.guardrailEvents[1].event_type).toBe('retrieval_stripped')
+    expect(result.guardrailEvents[1].stripped_content).toBe('Ignore previous instructions')
+  })
+
+  it('returns empty guardrail events when no event repo provided', async () => {
+    const wsRepo = mockWorkspaceRepo()
+    const convRepo = mockConversationRepo()
+
+    const useCase = new GetComplianceUseCase(wsRepo, convRepo)
+    const result = await useCase.execute('ws-test')
+
+    expect(result.guardrailEvents).toEqual([])
   })
 })

--- a/src/application/workspace/GetComplianceUseCase.ts
+++ b/src/application/workspace/GetComplianceUseCase.ts
@@ -1,5 +1,6 @@
 import type { WorkspaceRepository } from '../../domain/workspace/repository.js'
 import type { ConversationRepository } from '../../domain/conversation/repository.js'
+import type { GuardrailEventRepository, GuardrailEventData } from '../../domain/guardrail/repository.js'
 import { safeJsonParse } from '../../shared/json.js'
 
 interface ViolationItem { rule: string; description: string }
@@ -8,12 +9,14 @@ export class GetComplianceUseCase {
   constructor(
     private readonly workspaceRepo: WorkspaceRepository,
     private readonly conversationRepo: ConversationRepository,
+    private readonly guardrailEventRepo?: GuardrailEventRepository,
   ) {}
 
   async execute(workspaceId: string) {
-    const [guardrails, violationRows] = await Promise.all([
+    const [guardrails, violationRows, guardrailEvents] = await Promise.all([
       this.workspaceRepo.findGuardrails(workspaceId),
       this.conversationRepo.getComplianceViolationsByWorkspace(workspaceId, 20),
+      this.guardrailEventRepo ? this.guardrailEventRepo.findByWorkspace(workspaceId, 50) : Promise.resolve([] as GuardrailEventData[]),
     ])
 
     const violations: Array<ViolationItem & { conversation_id: string; user_name: string | null; timestamp: string | null }> = []
@@ -24,6 +27,6 @@ export class GetComplianceUseCase {
       }
     }
 
-    return { guardrails, violations }
+    return { guardrails, violations, guardrailEvents }
   }
 }

--- a/src/container.ts
+++ b/src/container.ts
@@ -17,6 +17,7 @@ import { ConsumerIntegrationTester } from './infrastructure/auth/ConsumerIntegra
 import { ConsumerPosterRegistryImpl } from './infrastructure/consumers/ConsumerPosterRegistryImpl.js'
 import { RedisSessionStore } from './infrastructure/session/RedisSessionStore.js'
 import { MysqlPromptTemplateRepository } from './infrastructure/persistence/mysql/MysqlPromptTemplateRepository.js'
+import { MysqlGuardrailEventRepository } from './infrastructure/persistence/mysql/MysqlGuardrailEventRepository.js'
 import { PromptResolver } from './application/prompt/PromptResolver.js'
 import { SavePromptUseCase } from './application/prompt/SavePromptUseCase.js'
 import { NoOpTenantService } from './infrastructure/tenant/NoOpTenantService.js'
@@ -134,7 +135,8 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
   const deleteConnectionUseCase = new DeleteConnectionUseCase(workspaceRepo)
   const getConnectionsUseCase = new GetConnectionsUseCase(workspaceRepo)
   const getKnowledgeUseCase = new GetKnowledgeUseCase(workspaceRepo, conversationRepo)
-  const getComplianceUseCase = new GetComplianceUseCase(workspaceRepo, conversationRepo)
+  const guardrailEventRepoForCompliance = new MysqlGuardrailEventRepository(pool)
+  const getComplianceUseCase = new GetComplianceUseCase(workspaceRepo, conversationRepo, guardrailEventRepoForCompliance)
   const getModelsUseCase = new GetModelsUseCase(modelRepo, orgRepo)
   const getHealthUseCase = new GetHealthUseCase(orgRepo, workspaceRepo)
 
@@ -267,7 +269,8 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
     log.warn({ plugin: event.pluginId, stripped: event.result.stripped }, 'Injection attempt detected in tool output')
   })
 
-  const executeQueryUseCase = new ExecuteQueryUseCase(workspaceRepo, orgRepo, auditRepo, providerRegistry, mcpFactory, manageConversationUseCase, resolveGuardrails, promptResolver, executionRails, retrievalRails)
+  const guardrailEventRepo = new MysqlGuardrailEventRepository(pool)
+  const executeQueryUseCase = new ExecuteQueryUseCase(workspaceRepo, orgRepo, auditRepo, providerRegistry, mcpFactory, manageConversationUseCase, resolveGuardrails, promptResolver, executionRails, retrievalRails, guardrailEventRepo)
   const sessionStore = new RedisSessionStore(REDIS_HOST, REDIS_PORT)
   const routeMessageUseCase = new RouteMessageUseCase(workspaceRepo, orgRepo, conversationRepo, sessionStore, executeQueryUseCase, manageConversationUseCase)
   const manageQueuesUseCase = new ManageQueuesUseCase(queueService)

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -482,6 +482,28 @@ const migrations: Migration[] = [
       `);
     },
   },
+  {
+    version: 15,
+    name: 'guardrail events table',
+    up: async (pool) => {
+      await pool.execute(`
+        CREATE TABLE IF NOT EXISTS guardrail_events (
+          id VARCHAR(64) PRIMARY KEY,
+          workspace_id VARCHAR(64) NOT NULL,
+          conversation_id VARCHAR(64),
+          event_type ENUM('execution_blocked', 'retrieval_stripped') NOT NULL,
+          plugin_id VARCHAR(64) NOT NULL,
+          tool_name VARCHAR(128),
+          original_query TEXT,
+          reason TEXT,
+          stripped_content TEXT,
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+          INDEX idx_workspace (workspace_id, created_at DESC),
+          INDEX idx_conversation (conversation_id)
+        )
+      `);
+    },
+  },
 ];
 
 interface SchemaMigrationRow extends mysql.RowDataPacket {

--- a/src/domain/guardrail/repository.ts
+++ b/src/domain/guardrail/repository.ts
@@ -1,0 +1,19 @@
+export type GuardrailEventType = 'execution_blocked' | 'retrieval_stripped'
+
+export interface GuardrailEventData {
+  id: string
+  workspace_id: string
+  conversation_id: string | null
+  event_type: GuardrailEventType
+  plugin_id: string
+  tool_name: string | null
+  original_query: string | null
+  reason: string | null
+  stripped_content: string | null
+  created_at?: string
+}
+
+export interface GuardrailEventRepository {
+  create(data: GuardrailEventData): Promise<void>
+  findByWorkspace(workspaceId: string, limit?: number): Promise<GuardrailEventData[]>
+}

--- a/src/infrastructure/persistence/mysql/MysqlGuardrailEventRepository.ts
+++ b/src/infrastructure/persistence/mysql/MysqlGuardrailEventRepository.ts
@@ -1,0 +1,45 @@
+import type mysql from 'mysql2/promise'
+import type { GuardrailEventRepository, GuardrailEventData } from '../../../domain/guardrail/repository.js'
+
+interface GuardrailEventRow extends mysql.RowDataPacket {
+  id: string
+  workspace_id: string
+  conversation_id: string | null
+  event_type: string
+  plugin_id: string
+  tool_name: string | null
+  original_query: string | null
+  reason: string | null
+  stripped_content: string | null
+  created_at: string
+}
+
+export class MysqlGuardrailEventRepository implements GuardrailEventRepository {
+  constructor(private readonly pool: mysql.Pool) {}
+
+  async create(data: GuardrailEventData): Promise<void> {
+    await this.pool.execute(
+      `INSERT INTO guardrail_events (id, workspace_id, conversation_id, event_type, plugin_id, tool_name, original_query, reason, stripped_content) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [data.id, data.workspace_id, data.conversation_id, data.event_type, data.plugin_id, data.tool_name, data.original_query, data.reason, data.stripped_content],
+    )
+  }
+
+  async findByWorkspace(workspaceId: string, limit = 50): Promise<GuardrailEventData[]> {
+    const [rows] = await this.pool.execute<GuardrailEventRow[]>(
+      `SELECT * FROM guardrail_events WHERE workspace_id = ? ORDER BY created_at DESC LIMIT ?`,
+      [workspaceId, limit],
+    )
+    return rows.map(r => ({
+      id: r.id,
+      workspace_id: r.workspace_id,
+      conversation_id: r.conversation_id,
+      event_type: r.event_type as GuardrailEventData['event_type'],
+      plugin_id: r.plugin_id,
+      tool_name: r.tool_name,
+      original_query: r.original_query,
+      reason: r.reason,
+      stripped_content: r.stripped_content,
+      created_at: r.created_at,
+    }))
+  }
+}


### PR DESCRIPTION
## Summary

- New `guardrail_events` table (migration 15) storing execution blocks and retrieval strips
- `ExecuteQueryUseCase` writes events with full context: workspace, conversation, tool name, query, reason
- `GetComplianceUseCase` returns `guardrailEvents` alongside existing violations
- Dashboard can now render real guardrail activity in the Violations tab

## Changes

- `domain/guardrail/repository.ts`: `GuardrailEventData` type and `GuardrailEventRepository` interface
- `infrastructure/persistence/mysql/MysqlGuardrailEventRepository.ts`: MySQL implementation
- `db/migrations.ts`: migration 15 (guardrail_events table)
- `application/query/ExecuteQueryUseCase.ts`: writes events on block/strip
- `application/workspace/GetComplianceUseCase.ts`: includes guardrailEvents in response
- `__tests__/mocks.ts`: mockGuardrailEventRepo

## Test plan

- [x] 287 tests passing (2 new)
- [x] TypeScript clean
- [x] Execution block writes event with tool name, query, reason
- [x] Retrieval strip writes event with stripped content (truncated to 500 chars)
- [x] Compliance API returns guardrailEvents array

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)