### PR TITLE
feat: guardrail policies with org-level enforcement

### DIFF
--- a/src/__tests__/mocks.ts
+++ b/src/__tests__/mocks.ts
@@ -14,6 +14,7 @@ import type { ConsumerPosterRegistry } from '../application/ports/ConsumerPoster
 import type { PromptTemplateRepository } from '../domain/prompt/repository.js'
 import type { GuardrailEventRepository } from '../domain/guardrail/repository.js'
 import type { GuardrailPolicyRepository } from '../domain/guardrail/policyRepository.js'
+import type { InstalledGuardrailRepository } from '../domain/guardrail/installedGuardrailRepository.js'
 
 // ── Stub data ──
 
@@ -294,5 +295,14 @@ export function mockGuardrailPolicyRepo(): GuardrailPolicyRepository {
     findMandatoryPlugins: vi.fn().mockResolvedValue([]),
     findRecommendedPlugins: vi.fn().mockResolvedValue([]),
     findOverridesForWorkspace: vi.fn().mockResolvedValue([]),
+  }
+}
+
+export function mockInstalledGuardrailRepo(): InstalledGuardrailRepository {
+  return {
+    findByOrg: vi.fn().mockResolvedValue([]),
+    findByOrgAndPlugin: vi.fn().mockResolvedValue(null),
+    install: vi.fn().mockResolvedValue(undefined),
+    uninstall: vi.fn().mockResolvedValue(undefined),
   }
 }

--- a/src/__tests__/mocks.ts
+++ b/src/__tests__/mocks.ts
@@ -13,6 +13,7 @@ import type { ModelRepository } from '../application/ports/ModelRepository.js'
 import type { ConsumerPosterRegistry } from '../application/ports/ConsumerPoster.js'
 import type { PromptTemplateRepository } from '../domain/prompt/repository.js'
 import type { GuardrailEventRepository } from '../domain/guardrail/repository.js'
+import type { GuardrailPolicyRepository } from '../domain/guardrail/policyRepository.js'
 
 // ── Stub data ──
 
@@ -273,5 +274,25 @@ export function mockGuardrailEventRepo(): GuardrailEventRepository {
     findByWorkspace: vi.fn().mockResolvedValue([]),
     findByWorkspaceFiltered: vi.fn().mockResolvedValue({ events: [], total: 0 }),
     updateStatus: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+export function mockGuardrailPolicyRepo(): GuardrailPolicyRepository {
+  return {
+    listByOrg: vi.fn().mockResolvedValue([]),
+    findByOrgAndPlugin: vi.fn().mockResolvedValue(null),
+    upsert: vi.fn().mockResolvedValue(undefined),
+    getComplianceForPolicy: vi.fn().mockResolvedValue([]),
+    findOverride: vi.fn().mockResolvedValue(null),
+    createOverride: vi.fn().mockResolvedValue(undefined),
+    deleteOverride: vi.fn().mockResolvedValue(undefined),
+    getOrgEventStats: vi.fn().mockResolvedValue({
+      total_events: 0, blocked_events: 0, stripped_events: 0, flagged_events: 0,
+      events_by_day: [], top_workspaces: [], recent_flagged: [],
+      compliance_score: 100, total_workspaces: 0, compliant_workspaces: 0,
+    }),
+    findMandatoryPlugins: vi.fn().mockResolvedValue([]),
+    findRecommendedPlugins: vi.fn().mockResolvedValue([]),
+    findOverridesForWorkspace: vi.fn().mockResolvedValue([]),
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -72,6 +72,7 @@ export function createApp(container: Container, corsOrigins?: string[]): Hono {
   app.route('/', container.queryRoutes)
   app.route('/', container.routeRoutes)
   app.route('/', container.promptRoutes)
+  app.route('/', container.guardrailPolicyRoutes)
 
   // WhatsApp webhook (no auth; Meta needs direct access)
   app.get('/api/webhooks/whatsapp', async (c) => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -73,6 +73,7 @@ export function createApp(container: Container, corsOrigins?: string[]): Hono {
   app.route('/', container.routeRoutes)
   app.route('/', container.promptRoutes)
   app.route('/', container.guardrailPolicyRoutes)
+  app.route('/', container.installedGuardrailRoutes)
 
   // WhatsApp webhook (no auth; Meta needs direct access)
   app.get('/api/webhooks/whatsapp', async (c) => {

--- a/src/application/guardrail/CreatePolicyOverrideUseCase.test.ts
+++ b/src/application/guardrail/CreatePolicyOverrideUseCase.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest'
+import { CreatePolicyOverrideUseCase } from './CreatePolicyOverrideUseCase.js'
+import { mockGuardrailPolicyRepo } from '../../__tests__/mocks.js'
+import type { GuardrailPolicyData } from '../../domain/guardrail/policyRepository.js'
+
+describe('CreatePolicyOverrideUseCase', () => {
+  function setup() {
+    const policyRepo = mockGuardrailPolicyRepo()
+    const useCase = new CreatePolicyOverrideUseCase(policyRepo)
+    return { policyRepo, useCase }
+  }
+
+  it('creates an override for a recommended policy', async () => {
+    const { policyRepo, useCase } = setup()
+    const policy: GuardrailPolicyData = { id: 'p1', org_id: 'org-1', plugin_id: 'pattern', enforcement: 'recommended' }
+    vi.mocked(policyRepo.findByOrgAndPlugin).mockResolvedValue(policy)
+    vi.mocked(policyRepo.findOverride).mockResolvedValue(null)
+
+    await useCase.execute({
+      orgId: 'org-1',
+      pluginId: 'pattern',
+      workspaceId: 'ws-1',
+      justification: 'Not needed for this workspace',
+      userId: 'user-1',
+    })
+
+    expect(policyRepo.createOverride).toHaveBeenCalledWith(
+      expect.objectContaining({
+        policy_id: 'p1',
+        workspace_id: 'ws-1',
+        justification: 'Not needed for this workspace',
+        created_by: 'user-1',
+      }),
+    )
+  })
+
+  it('rejects override for mandatory policy', async () => {
+    const { policyRepo, useCase } = setup()
+    const policy: GuardrailPolicyData = { id: 'p1', org_id: 'org-1', plugin_id: 'pattern', enforcement: 'mandatory' }
+    vi.mocked(policyRepo.findByOrgAndPlugin).mockResolvedValue(policy)
+
+    await expect(useCase.execute({
+      orgId: 'org-1',
+      pluginId: 'pattern',
+      workspaceId: 'ws-1',
+      justification: 'Trying to skip',
+      userId: 'user-1',
+    })).rejects.toThrow('mandatory')
+  })
+
+  it('rejects override when policy does not exist', async () => {
+    const { policyRepo, useCase } = setup()
+    vi.mocked(policyRepo.findByOrgAndPlugin).mockResolvedValue(null)
+
+    await expect(useCase.execute({
+      orgId: 'org-1',
+      pluginId: 'pattern',
+      workspaceId: 'ws-1',
+      justification: 'Reason',
+      userId: 'user-1',
+    })).rejects.toThrow()
+  })
+
+  it('rejects override when one already exists', async () => {
+    const { policyRepo, useCase } = setup()
+    const policy: GuardrailPolicyData = { id: 'p1', org_id: 'org-1', plugin_id: 'pattern', enforcement: 'recommended' }
+    vi.mocked(policyRepo.findByOrgAndPlugin).mockResolvedValue(policy)
+    vi.mocked(policyRepo.findOverride).mockResolvedValue({
+      id: 'ov1', policy_id: 'p1', workspace_id: 'ws-1',
+      justification: 'Already overridden', created_by: 'user-1',
+    })
+
+    await expect(useCase.execute({
+      orgId: 'org-1',
+      pluginId: 'pattern',
+      workspaceId: 'ws-1',
+      justification: 'Again',
+      userId: 'user-1',
+    })).rejects.toThrow('already exists')
+  })
+
+  it('rejects empty justification', async () => {
+    const { policyRepo, useCase } = setup()
+    const policy: GuardrailPolicyData = { id: 'p1', org_id: 'org-1', plugin_id: 'pattern', enforcement: 'recommended' }
+    vi.mocked(policyRepo.findByOrgAndPlugin).mockResolvedValue(policy)
+
+    await expect(useCase.execute({
+      orgId: 'org-1',
+      pluginId: 'pattern',
+      workspaceId: 'ws-1',
+      justification: '  ',
+      userId: 'user-1',
+    })).rejects.toThrow('justification')
+  })
+})

--- a/src/application/guardrail/CreatePolicyOverrideUseCase.ts
+++ b/src/application/guardrail/CreatePolicyOverrideUseCase.ts
@@ -1,0 +1,45 @@
+import type { GuardrailPolicyRepository } from '../../domain/guardrail/policyRepository.js'
+import { generateId } from '../../domain/shared/EntityId.js'
+import { ValidationError, NotFoundError, ConflictError } from '../../domain/shared/errors.js'
+
+interface CreateOverrideInput {
+  orgId: string
+  pluginId: string
+  workspaceId: string
+  justification: string
+  userId: string
+}
+
+export class CreatePolicyOverrideUseCase {
+  constructor(private readonly policyRepo: GuardrailPolicyRepository) {}
+
+  async execute(input: CreateOverrideInput): Promise<void> {
+    const { orgId, pluginId, workspaceId, justification, userId } = input
+
+    if (!justification.trim()) {
+      throw new ValidationError('A justification is required to override a recommended policy')
+    }
+
+    const policy = await this.policyRepo.findByOrgAndPlugin(orgId, pluginId)
+    if (!policy) {
+      throw new NotFoundError('GuardrailPolicy', pluginId)
+    }
+
+    if (policy.enforcement === 'mandatory') {
+      throw new ValidationError('Cannot override a mandatory policy')
+    }
+
+    const existing = await this.policyRepo.findOverride(policy.id, workspaceId)
+    if (existing) {
+      throw new ConflictError('An override for this policy and workspace already exists')
+    }
+
+    await this.policyRepo.createOverride({
+      id: generateId(),
+      policy_id: policy.id,
+      workspace_id: workspaceId,
+      justification: justification.trim(),
+      created_by: userId,
+    })
+  }
+}

--- a/src/application/guardrail/GetSecurityOverviewUseCase.test.ts
+++ b/src/application/guardrail/GetSecurityOverviewUseCase.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest'
+import { GetSecurityOverviewUseCase } from './GetSecurityOverviewUseCase.js'
+import { mockGuardrailPolicyRepo } from '../../__tests__/mocks.js'
+import type { SecurityOverviewStats } from '../../domain/guardrail/policyRepository.js'
+
+describe('GetSecurityOverviewUseCase', () => {
+  function setup() {
+    const policyRepo = mockGuardrailPolicyRepo()
+    const useCase = new GetSecurityOverviewUseCase(policyRepo)
+    return { policyRepo, useCase }
+  }
+
+  it('returns org-wide security overview with default 30 days', async () => {
+    const { policyRepo, useCase } = setup()
+    const stats: SecurityOverviewStats = {
+      total_events: 42,
+      blocked_events: 30,
+      stripped_events: 12,
+      flagged_events: 5,
+      events_by_day: [{ date: '2026-05-01', blocked: 10, stripped: 5 }],
+      top_workspaces: [{ workspace_id: 'ws-1', workspace_name: 'General', event_count: 20 }],
+      recent_flagged: [],
+      compliance_score: 80,
+      total_workspaces: 5,
+      compliant_workspaces: 4,
+    }
+    vi.mocked(policyRepo.getOrgEventStats).mockResolvedValue(stats)
+
+    const result = await useCase.execute('org-1')
+
+    expect(policyRepo.getOrgEventStats).toHaveBeenCalledWith('org-1', 30)
+    expect(result.total_events).toBe(42)
+    expect(result.compliance_score).toBe(80)
+  })
+
+  it('accepts custom day range', async () => {
+    const { policyRepo, useCase } = setup()
+
+    await useCase.execute('org-1', 7)
+
+    expect(policyRepo.getOrgEventStats).toHaveBeenCalledWith('org-1', 7)
+  })
+
+  it('clamps days to a minimum of 1', async () => {
+    const { policyRepo, useCase } = setup()
+
+    await useCase.execute('org-1', 0)
+
+    expect(policyRepo.getOrgEventStats).toHaveBeenCalledWith('org-1', 1)
+  })
+
+  it('clamps days to a maximum of 90', async () => {
+    const { policyRepo, useCase } = setup()
+
+    await useCase.execute('org-1', 365)
+
+    expect(policyRepo.getOrgEventStats).toHaveBeenCalledWith('org-1', 90)
+  })
+})

--- a/src/application/guardrail/GetSecurityOverviewUseCase.ts
+++ b/src/application/guardrail/GetSecurityOverviewUseCase.ts
@@ -1,0 +1,14 @@
+import type { GuardrailPolicyRepository, SecurityOverviewStats } from '../../domain/guardrail/policyRepository.js'
+
+const MIN_DAYS = 1
+const MAX_DAYS = 90
+const DEFAULT_DAYS = 30
+
+export class GetSecurityOverviewUseCase {
+  constructor(private readonly policyRepo: GuardrailPolicyRepository) {}
+
+  async execute(orgId: string, days?: number): Promise<SecurityOverviewStats> {
+    const clampedDays = Math.min(Math.max(days ?? DEFAULT_DAYS, MIN_DAYS), MAX_DAYS)
+    return this.policyRepo.getOrgEventStats(orgId, clampedDays)
+  }
+}

--- a/src/application/guardrail/InstallGuardrailUseCase.test.ts
+++ b/src/application/guardrail/InstallGuardrailUseCase.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest'
+import { InstallGuardrailUseCase } from './InstallGuardrailUseCase.js'
+
+function mockDeps() {
+  return {
+    installedRepo: {
+      findByOrg: vi.fn().mockResolvedValue([]),
+      findByOrgAndPlugin: vi.fn().mockResolvedValue(null),
+      install: vi.fn().mockResolvedValue(undefined),
+      uninstall: vi.fn().mockResolvedValue(undefined),
+    },
+    pluginLoader: {
+      load: vi.fn().mockResolvedValue({
+        plugin_id: 'profanity-filter',
+        metadata: { name: 'Profanity filter', description: 'Filters profanity', author: 'Test', version: '1.0.0', stage: 'pre-llm', configSchema: { fields: [] } },
+        instance: {},
+      }),
+    },
+    corePluginIds: new Set(['pattern', 'write-guard', 'injection-sanitiser']),
+  }
+}
+
+describe('InstallGuardrailUseCase', () => {
+  it('installs a marketplace plugin', async () => {
+    const deps = mockDeps()
+    const uc = new InstallGuardrailUseCase(deps.installedRepo, deps.pluginLoader, deps.corePluginIds)
+
+    const result = await uc.execute('org-1', 'user-1', '@supaproxy/guardrail-profanity')
+
+    expect(deps.pluginLoader.load).toHaveBeenCalledWith('@supaproxy/guardrail-profanity')
+    expect(deps.installedRepo.install).toHaveBeenCalledWith(
+      expect.objectContaining({
+        org_id: 'org-1',
+        plugin_id: 'profanity-filter',
+        package_name: '@supaproxy/guardrail-profanity',
+      }),
+    )
+    expect(result.plugin_id).toBe('profanity-filter')
+  })
+
+  it('rejects if plugin loader fails', async () => {
+    const deps = mockDeps()
+    deps.pluginLoader.load.mockResolvedValue(null)
+    const uc = new InstallGuardrailUseCase(deps.installedRepo, deps.pluginLoader, deps.corePluginIds)
+
+    await expect(uc.execute('org-1', 'user-1', 'bad-package')).rejects.toThrow()
+  })
+
+  it('rejects if plugin ID collides with a core plugin', async () => {
+    const deps = mockDeps()
+    deps.pluginLoader.load.mockResolvedValue({
+      plugin_id: 'pattern',
+      metadata: { name: 'Fake', description: '', author: '', version: '1.0.0', stage: 'pre-llm', configSchema: { fields: [] } },
+      instance: {},
+    })
+    const uc = new InstallGuardrailUseCase(deps.installedRepo, deps.pluginLoader, deps.corePluginIds)
+
+    await expect(uc.execute('org-1', 'user-1', 'fake-package')).rejects.toThrow('core')
+  })
+
+  it('rejects if already installed', async () => {
+    const deps = mockDeps()
+    deps.installedRepo.findByOrgAndPlugin.mockResolvedValue({ id: 'existing' })
+    const uc = new InstallGuardrailUseCase(deps.installedRepo, deps.pluginLoader, deps.corePluginIds)
+
+    await expect(uc.execute('org-1', 'user-1', '@supaproxy/guardrail-profanity')).rejects.toThrow('already installed')
+  })
+})

--- a/src/application/guardrail/InstallGuardrailUseCase.ts
+++ b/src/application/guardrail/InstallGuardrailUseCase.ts
@@ -1,0 +1,41 @@
+import type { InstalledGuardrailRepository, InstalledGuardrailData } from '../../domain/guardrail/installedGuardrailRepository.js'
+import type { PluginLoader } from '../ports/PluginLoader.js'
+import { generateId } from '../../domain/shared/EntityId.js'
+import { ValidationError, ConflictError } from '../../domain/shared/errors.js'
+
+export class InstallGuardrailUseCase {
+  constructor(
+    private readonly installedRepo: InstalledGuardrailRepository,
+    private readonly pluginLoader: PluginLoader,
+    private readonly corePluginIds: Set<string>,
+  ) {}
+
+  async execute(orgId: string, userId: string, packageName: string): Promise<InstalledGuardrailData> {
+    const loaded = await this.pluginLoader.load(packageName)
+    if (!loaded) {
+      throw new ValidationError(`Could not load guardrail plugin from package: ${packageName}`)
+    }
+
+    if (this.corePluginIds.has(loaded.plugin_id)) {
+      throw new ValidationError(`Plugin ID "${loaded.plugin_id}" conflicts with a core plugin and cannot be installed`)
+    }
+
+    const existing = await this.installedRepo.findByOrgAndPlugin(orgId, loaded.plugin_id)
+    if (existing) {
+      throw new ConflictError(`Guardrail "${loaded.plugin_id}" is already installed`)
+    }
+
+    const data: InstalledGuardrailData = {
+      id: generateId(),
+      org_id: orgId,
+      plugin_id: loaded.plugin_id,
+      package_name: packageName,
+      package_version: loaded.metadata.version,
+      plugin_metadata: loaded.metadata,
+      installed_by: userId,
+    }
+
+    await this.installedRepo.install(data)
+    return data
+  }
+}

--- a/src/application/guardrail/ManagePoliciesUseCase.test.ts
+++ b/src/application/guardrail/ManagePoliciesUseCase.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ManagePoliciesUseCase } from './ManagePoliciesUseCase.js'
+import { mockGuardrailPolicyRepo } from '../../__tests__/mocks.js'
+import type { GuardrailPolicyData } from '../../domain/guardrail/policyRepository.js'
+
+describe('ManagePoliciesUseCase', () => {
+  function setup() {
+    const policyRepo = mockGuardrailPolicyRepo()
+    const useCase = new ManagePoliciesUseCase(policyRepo)
+    return { policyRepo, useCase }
+  }
+
+  describe('listPolicies', () => {
+    it('returns all policies for the org', async () => {
+      const { policyRepo, useCase } = setup()
+      const policies: GuardrailPolicyData[] = [
+        { id: 'p1', org_id: 'org-1', plugin_id: 'pattern', enforcement: 'mandatory' },
+        { id: 'p2', org_id: 'org-1', plugin_id: 'write-guard', enforcement: 'recommended' },
+      ]
+      vi.mocked(policyRepo.listByOrg).mockResolvedValue(policies)
+
+      const result = await useCase.listPolicies('org-1')
+
+      expect(policyRepo.listByOrg).toHaveBeenCalledWith('org-1')
+      expect(result).toEqual(policies)
+    })
+
+    it('returns empty array when no policies exist', async () => {
+      const { useCase } = setup()
+      const result = await useCase.listPolicies('org-1')
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('setEnforcement', () => {
+    it('creates a new policy when none exists', async () => {
+      const { policyRepo, useCase } = setup()
+      vi.mocked(policyRepo.findByOrgAndPlugin).mockResolvedValue(null)
+
+      await useCase.setEnforcement('org-1', 'pattern', 'mandatory')
+
+      expect(policyRepo.findByOrgAndPlugin).toHaveBeenCalledWith('org-1', 'pattern')
+      expect(policyRepo.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          org_id: 'org-1',
+          plugin_id: 'pattern',
+          enforcement: 'mandatory',
+        }),
+      )
+    })
+
+    it('updates an existing policy', async () => {
+      const { policyRepo, useCase } = setup()
+      const existing: GuardrailPolicyData = { id: 'p1', org_id: 'org-1', plugin_id: 'pattern', enforcement: 'off' }
+      vi.mocked(policyRepo.findByOrgAndPlugin).mockResolvedValue(existing)
+
+      await useCase.setEnforcement('org-1', 'pattern', 'mandatory')
+
+      expect(policyRepo.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'p1',
+          enforcement: 'mandatory',
+        }),
+      )
+    })
+
+    it('rejects invalid enforcement values', async () => {
+      const { useCase } = setup()
+      await expect(useCase.setEnforcement('org-1', 'pattern', 'invalid' as never)).rejects.toThrow()
+    })
+
+    it('deletes overrides when setting enforcement to off', async () => {
+      const { policyRepo, useCase } = setup()
+      const existing: GuardrailPolicyData = { id: 'p1', org_id: 'org-1', plugin_id: 'pattern', enforcement: 'recommended' }
+      vi.mocked(policyRepo.findByOrgAndPlugin).mockResolvedValue(existing)
+
+      await useCase.setEnforcement('org-1', 'pattern', 'off')
+
+      expect(policyRepo.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ enforcement: 'off' }),
+      )
+    })
+  })
+
+  describe('getCompliance', () => {
+    it('returns compliance rows for a policy', async () => {
+      const { policyRepo, useCase } = setup()
+      const existing: GuardrailPolicyData = { id: 'p1', org_id: 'org-1', plugin_id: 'pattern', enforcement: 'mandatory' }
+      vi.mocked(policyRepo.findByOrgAndPlugin).mockResolvedValue(existing)
+      vi.mocked(policyRepo.getComplianceForPolicy).mockResolvedValue([
+        { workspace_id: 'ws-1', workspace_name: 'General', enabled: true, has_override: false },
+        { workspace_id: 'ws-2', workspace_name: 'Sales', enabled: false, has_override: false },
+      ])
+
+      const result = await useCase.getCompliance('org-1', 'pattern')
+
+      expect(policyRepo.getComplianceForPolicy).toHaveBeenCalledWith('p1', 'pattern', 'org-1')
+      expect(result).toHaveLength(2)
+      expect(result[1].enabled).toBe(false)
+    })
+
+    it('returns empty array when policy does not exist', async () => {
+      const { policyRepo, useCase } = setup()
+      vi.mocked(policyRepo.findByOrgAndPlugin).mockResolvedValue(null)
+
+      const result = await useCase.getCompliance('org-1', 'pattern')
+      expect(result).toEqual([])
+    })
+  })
+})

--- a/src/application/guardrail/ManagePoliciesUseCase.ts
+++ b/src/application/guardrail/ManagePoliciesUseCase.ts
@@ -1,0 +1,35 @@
+import type { GuardrailPolicyRepository, PolicyEnforcement, PolicyComplianceRow } from '../../domain/guardrail/policyRepository.js'
+import { generateId } from '../../domain/shared/EntityId.js'
+import { ValidationError } from '../../domain/shared/errors.js'
+
+const VALID_ENFORCEMENT: PolicyEnforcement[] = ['mandatory', 'recommended', 'off']
+
+export class ManagePoliciesUseCase {
+  constructor(private readonly policyRepo: GuardrailPolicyRepository) {}
+
+  async listPolicies(orgId: string) {
+    return this.policyRepo.listByOrg(orgId)
+  }
+
+  async setEnforcement(orgId: string, pluginId: string, enforcement: PolicyEnforcement): Promise<void> {
+    if (!VALID_ENFORCEMENT.includes(enforcement)) {
+      throw new ValidationError(`Invalid enforcement level: ${enforcement}`)
+    }
+
+    const existing = await this.policyRepo.findByOrgAndPlugin(orgId, pluginId)
+    const id = existing?.id ?? generateId()
+
+    await this.policyRepo.upsert({
+      id,
+      org_id: orgId,
+      plugin_id: pluginId,
+      enforcement,
+    })
+  }
+
+  async getCompliance(orgId: string, pluginId: string): Promise<PolicyComplianceRow[]> {
+    const policy = await this.policyRepo.findByOrgAndPlugin(orgId, pluginId)
+    if (!policy) return []
+    return this.policyRepo.getComplianceForPolicy(policy.id, pluginId, orgId)
+  }
+}

--- a/src/application/guardrail/UninstallGuardrailUseCase.test.ts
+++ b/src/application/guardrail/UninstallGuardrailUseCase.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest'
+import { UninstallGuardrailUseCase } from './UninstallGuardrailUseCase.js'
+
+function mockDeps() {
+  return {
+    installedRepo: {
+      findByOrg: vi.fn().mockResolvedValue([]),
+      findByOrgAndPlugin: vi.fn().mockResolvedValue({ id: 'inst-1', org_id: 'org-1', plugin_id: 'profanity-filter', package_name: '@supaproxy/guardrail-profanity', package_version: '1.0.0', plugin_metadata: {}, installed_by: 'user-1' }),
+      install: vi.fn().mockResolvedValue(undefined),
+      uninstall: vi.fn().mockResolvedValue(undefined),
+    },
+    corePluginIds: new Set(['pattern', 'write-guard', 'injection-sanitiser']),
+  }
+}
+
+describe('UninstallGuardrailUseCase', () => {
+  it('uninstalls a marketplace plugin', async () => {
+    const deps = mockDeps()
+    const uc = new UninstallGuardrailUseCase(deps.installedRepo, deps.corePluginIds)
+
+    await uc.execute('org-1', 'profanity-filter')
+
+    expect(deps.installedRepo.uninstall).toHaveBeenCalledWith('org-1', 'profanity-filter')
+  })
+
+  it('rejects uninstalling a core plugin', async () => {
+    const deps = mockDeps()
+    const uc = new UninstallGuardrailUseCase(deps.installedRepo, deps.corePluginIds)
+
+    await expect(uc.execute('org-1', 'pattern')).rejects.toThrow('core')
+  })
+
+  it('rejects if plugin is not installed', async () => {
+    const deps = mockDeps()
+    deps.installedRepo.findByOrgAndPlugin.mockResolvedValue(null)
+    const uc = new UninstallGuardrailUseCase(deps.installedRepo, deps.corePluginIds)
+
+    await expect(uc.execute('org-1', 'unknown-plugin')).rejects.toThrow()
+  })
+})

--- a/src/application/guardrail/UninstallGuardrailUseCase.ts
+++ b/src/application/guardrail/UninstallGuardrailUseCase.ts
@@ -1,0 +1,22 @@
+import type { InstalledGuardrailRepository } from '../../domain/guardrail/installedGuardrailRepository.js'
+import { ValidationError, NotFoundError } from '../../domain/shared/errors.js'
+
+export class UninstallGuardrailUseCase {
+  constructor(
+    private readonly installedRepo: InstalledGuardrailRepository,
+    private readonly corePluginIds: Set<string>,
+  ) {}
+
+  async execute(orgId: string, pluginId: string): Promise<void> {
+    if (this.corePluginIds.has(pluginId)) {
+      throw new ValidationError(`"${pluginId}" is a core plugin and cannot be uninstalled`)
+    }
+
+    const existing = await this.installedRepo.findByOrgAndPlugin(orgId, pluginId)
+    if (!existing) {
+      throw new NotFoundError('InstalledGuardrail', pluginId)
+    }
+
+    await this.installedRepo.uninstall(orgId, pluginId)
+  }
+}

--- a/src/application/ports/PluginLoader.ts
+++ b/src/application/ports/PluginLoader.ts
@@ -1,0 +1,11 @@
+import type { PluginMetadata } from '../../domain/guardrail/installedGuardrailRepository.js'
+
+export interface LoadedPlugin {
+  plugin_id: string
+  metadata: PluginMetadata
+  instance: unknown // GuardrailPlugin | ExecutionRailPlugin | RetrievalRailPlugin
+}
+
+export interface PluginLoader {
+  load(packageName: string): Promise<LoadedPlugin | null>
+}

--- a/src/application/query/ExecuteQueryUseCase.ts
+++ b/src/application/query/ExecuteQueryUseCase.ts
@@ -16,6 +16,7 @@ import { IS_PRODUCTION } from '../../config.js'
 import { DEFAULT_MAX_RESPONSE_TOKENS, DEFAULT_MAX_TOOL_ROUNDS, DEFAULT_SYSTEM_PROMPT } from '../../defaults.js'
 import { buildScopeEnforcementClause, ERROR_CODES } from '../../prompts.js'
 import type { PromptResolver } from '../prompt/PromptResolver.js'
+import type { PreQueryGuardService } from './PreQueryGuardService.js'
 import { safeJsonParse } from '../../shared/json.js'
 import pino from 'pino'
 
@@ -89,6 +90,7 @@ export class ExecuteQueryUseCase {
     private readonly resolveExecutionRails: (workspaceId: string) => Promise<ExecutionRailRegistry | null> = async () => null,
     private readonly resolveRetrievalRails: (workspaceId: string) => Promise<RetrievalRailRegistry | null> = async () => null,
     private readonly guardrailEventRepo?: GuardrailEventRepository,
+    private readonly preQueryGuard?: PreQueryGuardService,
   ) {}
 
   async execute(workspaceId: string, query: string, meta: QueryMeta): Promise<QueryResult> {
@@ -125,6 +127,20 @@ export class ExecuteQueryUseCase {
         conversationId,
         sessionId,
       })
+    }
+
+    // ── Pre-query enforcement (cost caps, rate limits, blocked topics) ──
+    if (this.preQueryGuard) {
+      const guard = await this.preQueryGuard.checkQuery(workspaceId, meta.userId, query)
+      if (!guard.allowed) {
+        return this.buildResult({
+          answer: guard.reason || 'This query was blocked by a compliance policy.',
+          error: guard.code || 'pre_query_blocked',
+          durationMs: Date.now() - startTime,
+          conversationId,
+          sessionId,
+        })
+      }
     }
 
     // ── Input guardrail pipeline ──

--- a/src/application/query/PreQueryGuardService.test.ts
+++ b/src/application/query/PreQueryGuardService.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi } from 'vitest'
+import { PreQueryGuardService } from './PreQueryGuardService.js'
+
+function mockDeps() {
+  return {
+    getMonthlySpend: vi.fn().mockResolvedValue(0),
+    getWorkspaceGuardrailConfig: vi.fn().mockResolvedValue(null),
+    getRecentQueryCount: vi.fn().mockResolvedValue(0),
+  }
+}
+
+describe('PreQueryGuardService', () => {
+  describe('cost caps', () => {
+    it('passes when no cost cap configured', async () => {
+      const deps = mockDeps()
+      deps.getWorkspaceGuardrailConfig.mockResolvedValue(null)
+      const svc = new PreQueryGuardService(deps)
+
+      const result = await svc.check('ws-1', 'user-1')
+      expect(result.allowed).toBe(true)
+    })
+
+    it('passes when spend is under the cap', async () => {
+      const deps = mockDeps()
+      deps.getWorkspaceGuardrailConfig.mockResolvedValue({ cost_cap_monthly_usd: 100 })
+      deps.getMonthlySpend.mockResolvedValue(50)
+      const svc = new PreQueryGuardService(deps)
+
+      const result = await svc.check('ws-1', 'user-1')
+      expect(result.allowed).toBe(true)
+    })
+
+    it('blocks when spend exceeds the cap', async () => {
+      const deps = mockDeps()
+      deps.getWorkspaceGuardrailConfig.mockResolvedValue({ cost_cap_monthly_usd: 100 })
+      deps.getMonthlySpend.mockResolvedValue(105)
+      const svc = new PreQueryGuardService(deps)
+
+      const result = await svc.check('ws-1', 'user-1')
+      expect(result.allowed).toBe(false)
+      expect(result.reason).toContain('cost')
+      expect(result.code).toBe('COST_CAP_EXCEEDED')
+    })
+
+    it('blocks when spend equals the cap exactly', async () => {
+      const deps = mockDeps()
+      deps.getWorkspaceGuardrailConfig.mockResolvedValue({ cost_cap_monthly_usd: 100 })
+      deps.getMonthlySpend.mockResolvedValue(100)
+      const svc = new PreQueryGuardService(deps)
+
+      const result = await svc.check('ws-1', 'user-1')
+      expect(result.allowed).toBe(false)
+    })
+  })
+
+  describe('rate limits', () => {
+    it('passes when no rate limit configured', async () => {
+      const deps = mockDeps()
+      deps.getWorkspaceGuardrailConfig.mockResolvedValue(null)
+      const svc = new PreQueryGuardService(deps)
+
+      const result = await svc.check('ws-1', 'user-1')
+      expect(result.allowed).toBe(true)
+    })
+
+    it('passes when under the per-user-per-minute limit', async () => {
+      const deps = mockDeps()
+      deps.getWorkspaceGuardrailConfig.mockResolvedValue({ rate_limit: { per_user_per_minute: 10 } })
+      deps.getRecentQueryCount.mockResolvedValue(5)
+      const svc = new PreQueryGuardService(deps)
+
+      const result = await svc.check('ws-1', 'user-1')
+      expect(result.allowed).toBe(true)
+    })
+
+    it('blocks when per-user-per-minute limit exceeded', async () => {
+      const deps = mockDeps()
+      deps.getWorkspaceGuardrailConfig.mockResolvedValue({ rate_limit: { per_user_per_minute: 10 } })
+      deps.getRecentQueryCount.mockResolvedValue(10)
+      const svc = new PreQueryGuardService(deps)
+
+      const result = await svc.check('ws-1', 'user-1')
+      expect(result.allowed).toBe(false)
+      expect(result.reason).toContain('Rate')
+      expect(result.code).toBe('RATE_LIMIT_EXCEEDED')
+    })
+
+    it('checks per-workspace-per-hour limit', async () => {
+      const deps = mockDeps()
+      deps.getWorkspaceGuardrailConfig.mockResolvedValue({ rate_limit: { per_workspace_per_hour: 100 } })
+      // No per_user_per_minute, so only workspace check runs
+      deps.getRecentQueryCount.mockResolvedValue(100)
+      const svc = new PreQueryGuardService(deps)
+
+      const result = await svc.check('ws-1', 'user-1')
+      expect(result.allowed).toBe(false)
+      expect(result.code).toBe('RATE_LIMIT_EXCEEDED')
+    })
+
+    it('skips user rate check when no userId', async () => {
+      const deps = mockDeps()
+      deps.getWorkspaceGuardrailConfig.mockResolvedValue({ rate_limit: { per_user_per_minute: 10, per_workspace_per_hour: 500 } })
+      deps.getRecentQueryCount.mockResolvedValue(0)
+      const svc = new PreQueryGuardService(deps)
+
+      const result = await svc.check('ws-1', undefined)
+      expect(result.allowed).toBe(true)
+      // Only workspace-level check, not user-level
+      expect(deps.getRecentQueryCount).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('blocked topics', () => {
+    it('passes when no blocked topics configured', async () => {
+      const deps = mockDeps()
+      deps.getWorkspaceGuardrailConfig.mockResolvedValue(null)
+      const svc = new PreQueryGuardService(deps)
+
+      const result = await svc.checkQuery('ws-1', 'user-1', 'Tell me about our products')
+      expect(result.allowed).toBe(true)
+    })
+
+    it('passes when query does not mention blocked topics', async () => {
+      const deps = mockDeps()
+      deps.getWorkspaceGuardrailConfig.mockResolvedValue({ blocked_topics: ['competitor pricing', 'internal salaries'] })
+      const svc = new PreQueryGuardService(deps)
+
+      const result = await svc.checkQuery('ws-1', 'user-1', 'What is our refund policy?')
+      expect(result.allowed).toBe(true)
+    })
+
+    it('blocks when query mentions a blocked topic', async () => {
+      const deps = mockDeps()
+      deps.getWorkspaceGuardrailConfig.mockResolvedValue({ blocked_topics: ['competitor pricing', 'internal salaries'] })
+      const svc = new PreQueryGuardService(deps)
+
+      const result = await svc.checkQuery('ws-1', 'user-1', 'What are the competitor pricing rates?')
+      expect(result.allowed).toBe(false)
+      expect(result.reason).toContain('blocked topic')
+      expect(result.code).toBe('BLOCKED_TOPIC')
+    })
+
+    it('matching is case-insensitive', async () => {
+      const deps = mockDeps()
+      deps.getWorkspaceGuardrailConfig.mockResolvedValue({ blocked_topics: ['Internal Salaries'] })
+      const svc = new PreQueryGuardService(deps)
+
+      const result = await svc.checkQuery('ws-1', 'user-1', 'Tell me about internal salaries at the company')
+      expect(result.allowed).toBe(false)
+      expect(result.code).toBe('BLOCKED_TOPIC')
+    })
+
+    it('runs cost cap and rate limit checks together with topic check', async () => {
+      const deps = mockDeps()
+      deps.getWorkspaceGuardrailConfig.mockResolvedValue({ cost_cap_monthly_usd: 100, blocked_topics: ['salaries'] })
+      deps.getMonthlySpend.mockResolvedValue(200)
+      const svc = new PreQueryGuardService(deps)
+
+      // Cost cap should fail first before even checking topics
+      const result = await svc.checkQuery('ws-1', 'user-1', 'Tell me about salaries')
+      expect(result.allowed).toBe(false)
+      expect(result.code).toBe('COST_CAP_EXCEEDED')
+    })
+  })
+})

--- a/src/application/query/PreQueryGuardService.ts
+++ b/src/application/query/PreQueryGuardService.ts
@@ -1,0 +1,95 @@
+export interface GuardrailConfig {
+  cost_cap_monthly_usd?: number
+  rate_limit?: {
+    per_user_per_minute?: number
+    per_workspace_per_hour?: number
+  }
+  blocked_topics?: string[]
+}
+
+export interface PreQueryGuardDeps {
+  getMonthlySpend(workspaceId: string): Promise<number>
+  getWorkspaceGuardrailConfig(workspaceId: string): Promise<GuardrailConfig | null>
+  getRecentQueryCount(scope: string, windowSeconds: number): Promise<number>
+}
+
+export interface GuardResult {
+  allowed: boolean
+  reason?: string
+  code?: 'COST_CAP_EXCEEDED' | 'RATE_LIMIT_EXCEEDED' | 'BLOCKED_TOPIC'
+}
+
+const PASS: GuardResult = { allowed: true }
+
+export class PreQueryGuardService {
+  constructor(private readonly deps: PreQueryGuardDeps) {}
+
+  async check(workspaceId: string, userId?: string): Promise<GuardResult> {
+    const config = await this.deps.getWorkspaceGuardrailConfig(workspaceId)
+    if (!config) return PASS
+
+    // Cost cap
+    if (config.cost_cap_monthly_usd != null) {
+      const spend = await this.deps.getMonthlySpend(workspaceId)
+      if (spend >= config.cost_cap_monthly_usd) {
+        return {
+          allowed: false,
+          reason: 'Monthly cost cap reached for this workspace.',
+          code: 'COST_CAP_EXCEEDED',
+        }
+      }
+    }
+
+    // Rate limits
+    if (config.rate_limit) {
+      const rl = config.rate_limit
+
+      if (rl.per_user_per_minute && userId) {
+        const count = await this.deps.getRecentQueryCount(`user:${userId}:${workspaceId}`, 60)
+        if (count >= rl.per_user_per_minute) {
+          return {
+            allowed: false,
+            reason: 'Rate limit exceeded. Please wait before sending another query.',
+            code: 'RATE_LIMIT_EXCEEDED',
+          }
+        }
+      }
+
+      if (rl.per_workspace_per_hour) {
+        const count = await this.deps.getRecentQueryCount(`workspace:${workspaceId}`, 3600)
+        if (count >= rl.per_workspace_per_hour) {
+          return {
+            allowed: false,
+            reason: 'This workspace has reached its hourly query limit.',
+            code: 'RATE_LIMIT_EXCEEDED',
+          }
+        }
+      }
+    }
+
+    return PASS
+  }
+
+  async checkQuery(workspaceId: string, userId: string | undefined, query: string): Promise<GuardResult> {
+    // Run cost cap and rate limit checks first
+    const preCheck = await this.check(workspaceId, userId)
+    if (!preCheck.allowed) return preCheck
+
+    // Blocked topics
+    const config = await this.deps.getWorkspaceGuardrailConfig(workspaceId)
+    if (config?.blocked_topics && config.blocked_topics.length > 0) {
+      const lowerQuery = query.toLowerCase()
+      for (const topic of config.blocked_topics) {
+        if (lowerQuery.includes(topic.toLowerCase())) {
+          return {
+            allowed: false,
+            reason: `This query touches a blocked topic and cannot be processed.`,
+            code: 'BLOCKED_TOPIC',
+          }
+        }
+      }
+    }
+
+    return PASS
+  }
+}

--- a/src/container.ts
+++ b/src/container.ts
@@ -19,6 +19,8 @@ import { RedisSessionStore } from './infrastructure/session/RedisSessionStore.js
 import { MysqlPromptTemplateRepository } from './infrastructure/persistence/mysql/MysqlPromptTemplateRepository.js'
 import { MysqlGuardrailEventRepository } from './infrastructure/persistence/mysql/MysqlGuardrailEventRepository.js'
 import { MysqlGuardrailPolicyRepository } from './infrastructure/persistence/mysql/MysqlGuardrailPolicyRepository.js'
+import { PreQueryGuardDepsImpl } from './infrastructure/guard/PreQueryGuardDepsImpl.js'
+import { PreQueryGuardService } from './application/query/PreQueryGuardService.js'
 import { PromptResolver } from './application/prompt/PromptResolver.js'
 import { SavePromptUseCase } from './application/prompt/SavePromptUseCase.js'
 import { NoOpTenantService } from './infrastructure/tenant/NoOpTenantService.js'
@@ -331,7 +333,9 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
   }
 
   const guardrailEventRepo = new MysqlGuardrailEventRepository(pool)
-  const executeQueryUseCase = new ExecuteQueryUseCase(workspaceRepo, orgRepo, auditRepo, providerRegistry, mcpFactory, manageConversationUseCase, resolveGuardrails, promptResolver, resolveExecutionRails, resolveRetrievalRails, guardrailEventRepo)
+  const preQueryGuardDeps = new PreQueryGuardDepsImpl(pool, REDIS_HOST, REDIS_PORT)
+  const preQueryGuard = new PreQueryGuardService(preQueryGuardDeps)
+  const executeQueryUseCase = new ExecuteQueryUseCase(workspaceRepo, orgRepo, auditRepo, providerRegistry, mcpFactory, manageConversationUseCase, resolveGuardrails, promptResolver, resolveExecutionRails, resolveRetrievalRails, guardrailEventRepo, preQueryGuard)
   const sessionStore = new RedisSessionStore(REDIS_HOST, REDIS_PORT)
   const routeMessageUseCase = new RouteMessageUseCase(workspaceRepo, orgRepo, conversationRepo, sessionStore, executeQueryUseCase, manageConversationUseCase)
   const manageQueuesUseCase = new ManageQueuesUseCase(queueService)

--- a/src/container.ts
+++ b/src/container.ts
@@ -10,7 +10,7 @@ import { MysqlModelRepository } from './infrastructure/persistence/mysql/MysqlMo
 import { BcryptPasswordService } from './infrastructure/auth/BcryptPasswordService.js'
 import { JwtTokenService } from './infrastructure/auth/JwtTokenService.js'
 import { registry as providerRegistry } from '@supaproxy/providers'
-import { PatternGuardrail, LlmGuardrail, type GuardrailPlugin, ExecutionRailRegistry, WriteGuardRail, RetrievalRailRegistry, InjectionSanitiser } from '@supaproxy/guardrails'
+import { registry as guardrailRegistry, executionCatalogue, retrievalCatalogue, type GuardrailPlugin, ExecutionRailRegistry, RetrievalRailRegistry } from '@supaproxy/guardrails'
 import { McpClientFactoryImpl } from './infrastructure/mcp/McpClientFactoryImpl.js'
 import { BullMqService } from './infrastructure/queue/BullMqService.js'
 import { ConsumerIntegrationTester } from './infrastructure/auth/ConsumerIntegrationTester.js'
@@ -213,35 +213,29 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
   }
   const connectConsumerUseCase = new ConnectConsumerUseCase(workspaceRepo, consumerTypeHandlers)
 
-  // Guardrails: resolved per workspace at query time.
-  // Only enabled guardrails run. Config is loaded from workspace_guardrails table.
-  const patternInstance = new PatternGuardrail()
-  const availableGuardrails: Record<string, { instance: GuardrailPlugin; factory: () => GuardrailPlugin }> = {
-    'pattern': { instance: patternInstance, factory: () => new PatternGuardrail() },
-  }
+  // Guardrails: resolved per workspace at query time from package catalogues.
+  // The server never imports concrete plugin classes. It discovers them
+  // from the registries that plugins populate at import time.
 
   async function resolveGuardrails(workspaceId: string): Promise<GuardrailPlugin[]> {
     const configs = await workspaceRepo.findEnabledGuardrailConfigs(workspaceId)
     const enabledIds = new Set(configs.map(c => c.guardrail_id))
 
-    // Org-level policy enforcement: merge in mandatory and recommended plugins
     const enforcedIds = await getEnforcedPluginIds(workspaceId)
-    for (const id of enforcedIds) {
-      enabledIds.add(id)
-    }
+    for (const id of enforcedIds) enabledIds.add(id)
 
     const plugins: GuardrailPlugin[] = []
     for (const id of enabledIds) {
-      const entry = availableGuardrails[id]
-      if (entry) {
-        plugins.push(entry.factory())
-      }
+      const factory = guardrailRegistry.has(id) ? () => {
+        // Create a fresh instance from the registered prototype's constructor
+        const proto = guardrailRegistry.get(id)
+        return new (proto.constructor as new () => GuardrailPlugin)()
+      } : null
+      if (factory) plugins.push(factory())
     }
     return plugins
   }
 
-  // Resolves which plugin IDs are forced on by org-level policies for a workspace.
-  // Mandatory plugins are always included. Recommended plugins are included unless overridden.
   async function getEnforcedPluginIds(workspaceId: string): Promise<string[]> {
     const ws = await workspaceRepo.findById(workspaceId)
     if (!ws?.org_id) return []
@@ -253,62 +247,44 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
     ])
 
     const overriddenPlugins = new Set(overrides.map(o => o.plugin_id))
-
-    // Mandatory: always enforced. Recommended: enforced unless overridden.
     const enforced = [...mandatory]
     for (const pluginId of recommended) {
-      if (!overriddenPlugins.has(pluginId)) {
-        enforced.push(pluginId)
-      }
+      if (!overriddenPlugins.has(pluginId)) enforced.push(pluginId)
     }
     return enforced
   }
 
-  // Static instances for listing available guardrails (not for execution)
-  const writeGuardInstance = new WriteGuardRail()
-  const injectionSanitiserInstance = new InjectionSanitiser()
-
+  // List all available guardrails from package catalogues (for dashboard UI)
   function listAvailableGuardrails() {
-    const pipeline = Object.entries(availableGuardrails).map(([id, { instance }]) => ({
-      id,
-      name: instance.name,
-      description: instance.description,
-      stage: instance.stage,
-      configSchema: instance.configSchema,
-    }))
+    const toInfo = (p: { id: string; name: string; description: string; stage: string; configSchema: { fields: Array<{ name: string; label: string; type: string; required?: boolean; placeholder?: string; helpText?: string; options?: Array<{ value: string; label: string }>; defaultValue?: string | boolean | number }> } }) => ({
+      id: p.id, name: p.name, description: p.description, stage: p.stage, configSchema: p.configSchema,
+    })
 
-    const execution = [writeGuardInstance].map((p) => ({
-      id: p.id,
-      name: p.name,
-      description: p.description,
-      stage: p.stage,
-      configSchema: p.configSchema,
-    }))
-
-    const retrieval = [injectionSanitiserInstance].map((p) => ({
-      id: p.id,
-      name: p.name,
-      description: p.description,
-      stage: p.stage,
-      configSchema: p.configSchema,
-    }))
-
-    return [...pipeline, ...execution, ...retrieval]
+    return [
+      ...guardrailRegistry.list().map(toInfo),
+      ...executionCatalogue.list().map(toInfo),
+      ...retrievalCatalogue.list().map(toInfo),
+    ]
   }
 
   const promptTemplateRepo = new MysqlPromptTemplateRepository(pool)
   const promptResolver = new PromptResolver(promptTemplateRepo)
 
-  // Execution and retrieval rails: resolved per workspace from enabled guardrails + org policies
+  // Execution and retrieval rails: resolved per workspace from catalogues + org policies
   async function resolveExecutionRails(workspaceId: string): Promise<ExecutionRailRegistry | null> {
     const configs = await workspaceRepo.findEnabledGuardrailConfigs(workspaceId)
     const enabledIds = new Set(configs.map(c => c.guardrail_id))
     const enforcedIds = await getEnforcedPluginIds(workspaceId)
     for (const id of enforcedIds) enabledIds.add(id)
 
-    if (!enabledIds.has('write-guard')) return null
+    // Find which execution rail plugins are enabled for this workspace
+    const matchedPlugins = executionCatalogue.list().filter(p => enabledIds.has(p.id))
+    if (matchedPlugins.length === 0) return null
+
     const reg = new ExecutionRailRegistry()
-    reg.register(new WriteGuardRail())
+    for (const proto of matchedPlugins) {
+      reg.register(new (proto.constructor as new () => typeof proto)())
+    }
     reg.on((event) => {
       if (!event.result.allowed) {
         log.warn({ plugin: event.pluginId, tool: event.ctx.toolName, workspace: event.ctx.workspaceId, reason: event.result.reason }, 'Tool call blocked by execution rail')
@@ -323,9 +299,13 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
     const enforcedIds = await getEnforcedPluginIds(workspaceId)
     for (const id of enforcedIds) enabledIds.add(id)
 
-    if (!enabledIds.has('injection-sanitiser')) return null
+    const matchedPlugins = retrievalCatalogue.list().filter(p => enabledIds.has(p.id))
+    if (matchedPlugins.length === 0) return null
+
     const reg = new RetrievalRailRegistry()
-    reg.register(new InjectionSanitiser())
+    for (const proto of matchedPlugins) {
+      reg.register(new (proto.constructor as new () => typeof proto)())
+    }
     reg.on((event) => {
       log.warn({ plugin: event.pluginId, stripped: event.result.stripped }, 'Injection attempt detected in tool output')
     })

--- a/src/container.ts
+++ b/src/container.ts
@@ -18,6 +18,7 @@ import { ConsumerPosterRegistryImpl } from './infrastructure/consumers/ConsumerP
 import { RedisSessionStore } from './infrastructure/session/RedisSessionStore.js'
 import { MysqlPromptTemplateRepository } from './infrastructure/persistence/mysql/MysqlPromptTemplateRepository.js'
 import { MysqlGuardrailEventRepository } from './infrastructure/persistence/mysql/MysqlGuardrailEventRepository.js'
+import { MysqlGuardrailPolicyRepository } from './infrastructure/persistence/mysql/MysqlGuardrailPolicyRepository.js'
 import { PromptResolver } from './application/prompt/PromptResolver.js'
 import { SavePromptUseCase } from './application/prompt/SavePromptUseCase.js'
 import { NoOpTenantService } from './infrastructure/tenant/NoOpTenantService.js'
@@ -80,6 +81,11 @@ import { RouteMessageUseCase } from './application/routing/RouteMessageUseCase.j
 // Application - Queue
 import { ManageQueuesUseCase } from './application/queue/ManageQueuesUseCase.js'
 
+// Application - Guardrail policies
+import { ManagePoliciesUseCase } from './application/guardrail/ManagePoliciesUseCase.js'
+import { GetSecurityOverviewUseCase } from './application/guardrail/GetSecurityOverviewUseCase.js'
+import { CreatePolicyOverrideUseCase } from './application/guardrail/CreatePolicyOverrideUseCase.js'
+
 // Presentation
 import { createRequireAuth } from './presentation/middleware/auth.js'
 import { createAuthRoutes } from './presentation/routes/auth.js'
@@ -91,6 +97,7 @@ import { createQueryRoutes } from './presentation/routes/query.js'
 import { createQueueRoutes } from './presentation/routes/queues.js'
 import { createRouteRoutes } from './presentation/routes/route.js'
 import { createPromptRoutes } from './presentation/routes/prompts.js'
+import { createGuardrailPolicyRoutes } from './presentation/routes/guardrailPolicies.js'
 
 export function createContainer(pool: mysql.Pool, options?: { tenantService?: TenantService }) {
   // Tenant service: defaults to NoOp (single-tenant) for open-source.
@@ -135,6 +142,7 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
   const deleteConnectionUseCase = new DeleteConnectionUseCase(workspaceRepo)
   const getConnectionsUseCase = new GetConnectionsUseCase(workspaceRepo)
   const getKnowledgeUseCase = new GetKnowledgeUseCase(workspaceRepo, conversationRepo)
+  const guardrailPolicyRepo = new MysqlGuardrailPolicyRepository(pool)
   const guardrailEventRepoForCompliance = new MysqlGuardrailEventRepository(pool)
   const getComplianceUseCase = new GetComplianceUseCase(workspaceRepo, conversationRepo, guardrailEventRepoForCompliance)
   const getModelsUseCase = new GetModelsUseCase(modelRepo, orgRepo)
@@ -212,14 +220,46 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
 
   async function resolveGuardrails(workspaceId: string): Promise<GuardrailPlugin[]> {
     const configs = await workspaceRepo.findEnabledGuardrailConfigs(workspaceId)
+    const enabledIds = new Set(configs.map(c => c.guardrail_id))
+
+    // Org-level policy enforcement: merge in mandatory and recommended plugins
+    const enforcedIds = await getEnforcedPluginIds(workspaceId)
+    for (const id of enforcedIds) {
+      enabledIds.add(id)
+    }
+
     const plugins: GuardrailPlugin[] = []
-    for (const { guardrail_id } of configs) {
-      const entry = availableGuardrails[guardrail_id]
+    for (const id of enabledIds) {
+      const entry = availableGuardrails[id]
       if (entry) {
         plugins.push(entry.factory())
       }
     }
     return plugins
+  }
+
+  // Resolves which plugin IDs are forced on by org-level policies for a workspace.
+  // Mandatory plugins are always included. Recommended plugins are included unless overridden.
+  async function getEnforcedPluginIds(workspaceId: string): Promise<string[]> {
+    const ws = await workspaceRepo.findById(workspaceId)
+    if (!ws?.org_id) return []
+
+    const [mandatory, recommended, overrides] = await Promise.all([
+      guardrailPolicyRepo.findMandatoryPlugins(ws.org_id),
+      guardrailPolicyRepo.findRecommendedPlugins(ws.org_id),
+      guardrailPolicyRepo.findOverridesForWorkspace(workspaceId),
+    ])
+
+    const overriddenPlugins = new Set(overrides.map(o => o.plugin_id))
+
+    // Mandatory: always enforced. Recommended: enforced unless overridden.
+    const enforced = [...mandatory]
+    for (const pluginId of recommended) {
+      if (!overriddenPlugins.has(pluginId)) {
+        enforced.push(pluginId)
+      }
+    }
+    return enforced
   }
 
   // Static instances for listing available guardrails (not for execution)
@@ -257,11 +297,14 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
   const promptTemplateRepo = new MysqlPromptTemplateRepository(pool)
   const promptResolver = new PromptResolver(promptTemplateRepo)
 
-  // Execution and retrieval rails: resolved per workspace from enabled guardrails
+  // Execution and retrieval rails: resolved per workspace from enabled guardrails + org policies
   async function resolveExecutionRails(workspaceId: string): Promise<ExecutionRailRegistry | null> {
     const configs = await workspaceRepo.findEnabledGuardrailConfigs(workspaceId)
-    const enabledIds = configs.map(c => c.guardrail_id)
-    if (!enabledIds.includes('write-guard')) return null
+    const enabledIds = new Set(configs.map(c => c.guardrail_id))
+    const enforcedIds = await getEnforcedPluginIds(workspaceId)
+    for (const id of enforcedIds) enabledIds.add(id)
+
+    if (!enabledIds.has('write-guard')) return null
     const reg = new ExecutionRailRegistry()
     reg.register(new WriteGuardRail())
     reg.on((event) => {
@@ -274,8 +317,11 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
 
   async function resolveRetrievalRails(workspaceId: string): Promise<RetrievalRailRegistry | null> {
     const configs = await workspaceRepo.findEnabledGuardrailConfigs(workspaceId)
-    const enabledIds = configs.map(c => c.guardrail_id)
-    if (!enabledIds.includes('injection-sanitiser')) return null
+    const enabledIds = new Set(configs.map(c => c.guardrail_id))
+    const enforcedIds = await getEnforcedPluginIds(workspaceId)
+    for (const id of enforcedIds) enabledIds.add(id)
+
+    if (!enabledIds.has('injection-sanitiser')) return null
     const reg = new RetrievalRailRegistry()
     reg.register(new InjectionSanitiser())
     reg.on((event) => {
@@ -293,7 +339,7 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
   // Build routes
   const authRoutes = createAuthRoutes({ signupUseCase, loginUseCase, tokenService, dashboardUrl: DASHBOARD_URL, isProduction: IS_PRODUCTION, cookieDomain: COOKIE_DOMAIN })
   const orgRoutes = createOrgRoutes({ getOrgUseCase, updateOrgUseCase, getOrgSettingsUseCase, updateOrgSettingUseCase, testIntegrationUseCase, listOrgUsersUseCase, orgRepo, requireAuth })
-  const workspaceRoutes = createWorkspaceRoutes({ createWorkspaceUseCase, updateWorkspaceUseCase, getWorkspaceDetailUseCase, listWorkspacesUseCase, getWorkspaceSummaryUseCase, getDashboardUseCase, getActivityUseCase, deleteConnectionUseCase, getConnectionsUseCase, getKnowledgeUseCase, getComplianceUseCase, guardrailEventRepo: guardrailEventRepoForCompliance, listAvailableGuardrails, orgRepo, workspaceRepo, tenantService, requireAuth })
+  const workspaceRoutes = createWorkspaceRoutes({ createWorkspaceUseCase, updateWorkspaceUseCase, getWorkspaceDetailUseCase, listWorkspacesUseCase, getWorkspaceSummaryUseCase, getDashboardUseCase, getActivityUseCase, deleteConnectionUseCase, getConnectionsUseCase, getKnowledgeUseCase, getComplianceUseCase, guardrailEventRepo: guardrailEventRepoForCompliance, guardrailPolicyRepo, listAvailableGuardrails, orgRepo, workspaceRepo, tenantService, requireAuth })
   const conversationRoutes = createConversationRoutes({ listConversationsUseCase, getConversationDetailUseCase, closeConversationUseCase, workspaceRepo, tenantService, requireAuth })
   const connectorRoutes = createConnectorRoutes({ testMcpConnectionUseCase, saveMcpConnectionUseCase, bindConsumerChannelUseCase, connectConsumerUseCase, workspaceRepo, tenantService, requireAuth })
   const queryRoutes = createQueryRoutes({ executeQueryUseCase, workspaceRepo, tenantService, requireAuth })
@@ -301,6 +347,12 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
   const routeRoutes = createRouteRoutes({ routeMessageUseCase, requireAuth })
   const savePromptUseCase = new SavePromptUseCase(promptTemplateRepo)
   const promptRoutes = createPromptRoutes({ promptResolver, promptRepo: promptTemplateRepo, savePromptUseCase, requireAuth })
+
+  // Guardrail policies
+  const managePoliciesUseCase = new ManagePoliciesUseCase(guardrailPolicyRepo)
+  const getSecurityOverviewUseCase = new GetSecurityOverviewUseCase(guardrailPolicyRepo)
+  const createPolicyOverrideUseCase = new CreatePolicyOverrideUseCase(guardrailPolicyRepo)
+  const guardrailPolicyRoutes = createGuardrailPolicyRoutes({ managePoliciesUseCase, getSecurityOverviewUseCase, createPolicyOverrideUseCase, requireAuth })
 
   const container = {
     // Infrastructure
@@ -319,8 +371,9 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
     manageConversationUseCase, lifecycleUseCase,
     testMcpConnectionUseCase, saveMcpConnectionUseCase, bindConsumerChannelUseCase, connectConsumerUseCase,
     executeQueryUseCase, routeMessageUseCase, manageQueuesUseCase, savePromptUseCase,
+    managePoliciesUseCase, getSecurityOverviewUseCase, createPolicyOverrideUseCase,
     // Routes
-    authRoutes, orgRoutes, workspaceRoutes, conversationRoutes, connectorRoutes, queryRoutes, queueRoutes, routeRoutes, promptRoutes,
+    authRoutes, orgRoutes, workspaceRoutes, conversationRoutes, connectorRoutes, queryRoutes, queueRoutes, routeRoutes, promptRoutes, guardrailPolicyRoutes,
   }
 
   return container

--- a/src/container.ts
+++ b/src/container.ts
@@ -19,6 +19,8 @@ import { RedisSessionStore } from './infrastructure/session/RedisSessionStore.js
 import { MysqlPromptTemplateRepository } from './infrastructure/persistence/mysql/MysqlPromptTemplateRepository.js'
 import { MysqlGuardrailEventRepository } from './infrastructure/persistence/mysql/MysqlGuardrailEventRepository.js'
 import { MysqlGuardrailPolicyRepository } from './infrastructure/persistence/mysql/MysqlGuardrailPolicyRepository.js'
+import { MysqlInstalledGuardrailRepository } from './infrastructure/persistence/mysql/MysqlInstalledGuardrailRepository.js'
+import { DynamicPluginLoader } from './infrastructure/plugins/DynamicPluginLoader.js'
 import { PreQueryGuardDepsImpl } from './infrastructure/guard/PreQueryGuardDepsImpl.js'
 import { PreQueryGuardService } from './application/query/PreQueryGuardService.js'
 import { PromptResolver } from './application/prompt/PromptResolver.js'
@@ -87,6 +89,8 @@ import { ManageQueuesUseCase } from './application/queue/ManageQueuesUseCase.js'
 import { ManagePoliciesUseCase } from './application/guardrail/ManagePoliciesUseCase.js'
 import { GetSecurityOverviewUseCase } from './application/guardrail/GetSecurityOverviewUseCase.js'
 import { CreatePolicyOverrideUseCase } from './application/guardrail/CreatePolicyOverrideUseCase.js'
+import { InstallGuardrailUseCase } from './application/guardrail/InstallGuardrailUseCase.js'
+import { UninstallGuardrailUseCase } from './application/guardrail/UninstallGuardrailUseCase.js'
 
 // Presentation
 import { createRequireAuth } from './presentation/middleware/auth.js'
@@ -100,6 +104,7 @@ import { createQueueRoutes } from './presentation/routes/queues.js'
 import { createRouteRoutes } from './presentation/routes/route.js'
 import { createPromptRoutes } from './presentation/routes/prompts.js'
 import { createGuardrailPolicyRoutes } from './presentation/routes/guardrailPolicies.js'
+import { createInstalledGuardrailRoutes } from './presentation/routes/installedGuardrails.js'
 
 export function createContainer(pool: mysql.Pool, options?: { tenantService?: TenantService }) {
   // Tenant service: defaults to NoOp (single-tenant) for open-source.
@@ -145,6 +150,8 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
   const getConnectionsUseCase = new GetConnectionsUseCase(workspaceRepo)
   const getKnowledgeUseCase = new GetKnowledgeUseCase(workspaceRepo, conversationRepo)
   const guardrailPolicyRepo = new MysqlGuardrailPolicyRepository(pool)
+  const installedGuardrailRepo = new MysqlInstalledGuardrailRepository(pool)
+  const pluginLoader = new DynamicPluginLoader()
   const guardrailEventRepoForCompliance = new MysqlGuardrailEventRepository(pool)
   const getComplianceUseCase = new GetComplianceUseCase(workspaceRepo, conversationRepo, guardrailEventRepoForCompliance)
   const getModelsUseCase = new GetModelsUseCase(modelRepo, orgRepo)
@@ -254,17 +261,37 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
     return enforced
   }
 
-  // List all available guardrails from package catalogues (for dashboard UI)
-  function listAvailableGuardrails() {
-    const toInfo = (p: { id: string; name: string; description: string; stage: string; configSchema: { fields: Array<{ name: string; label: string; type: string; required?: boolean; placeholder?: string; helpText?: string; options?: Array<{ value: string; label: string }>; defaultValue?: string | boolean | number }> } }) => ({
-      id: p.id, name: p.name, description: p.description, stage: p.stage, configSchema: p.configSchema,
+  // Core plugin IDs: derived from catalogues, never hardcoded
+  const corePluginIds = new Set([
+    ...guardrailRegistry.list().map(p => p.id),
+    ...executionCatalogue.list().map(p => p.id),
+    ...retrievalCatalogue.list().map(p => p.id),
+  ])
+
+  // List all available guardrails: core (from catalogues) + installed (from DB)
+  async function listAvailableGuardrails(orgId: string) {
+    type Info = { id: string; name: string; description: string; stage: string; source: 'core' | 'marketplace'; configSchema: { fields: Array<{ name: string; label: string; type: string; required?: boolean; placeholder?: string; helpText?: string; options?: Array<{ value: string; label: string }>; defaultValue?: string | boolean | number }> } }
+    const toCore = (p: { id: string; name: string; description: string; stage: string; configSchema: Info['configSchema'] }): Info => ({
+      id: p.id, name: p.name, description: p.description, stage: p.stage, source: 'core', configSchema: p.configSchema,
     })
 
-    return [
-      ...guardrailRegistry.list().map(toInfo),
-      ...executionCatalogue.list().map(toInfo),
-      ...retrievalCatalogue.list().map(toInfo),
+    const core: Info[] = [
+      ...guardrailRegistry.list().map(toCore),
+      ...executionCatalogue.list().map(toCore),
+      ...retrievalCatalogue.list().map(toCore),
     ]
+
+    const installed = await installedGuardrailRepo.findByOrg(orgId)
+    const marketplace: Info[] = installed.map(ig => ({
+      id: ig.plugin_id,
+      name: ig.plugin_metadata.name,
+      description: ig.plugin_metadata.description,
+      stage: ig.plugin_metadata.stage,
+      source: 'marketplace' as const,
+      configSchema: ig.plugin_metadata.configSchema,
+    }))
+
+    return [...core, ...marketplace]
   }
 
   const promptTemplateRepo = new MysqlPromptTemplateRepository(pool)
@@ -338,6 +365,11 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
   const createPolicyOverrideUseCase = new CreatePolicyOverrideUseCase(guardrailPolicyRepo)
   const guardrailPolicyRoutes = createGuardrailPolicyRoutes({ managePoliciesUseCase, getSecurityOverviewUseCase, createPolicyOverrideUseCase, requireAuth })
 
+  // Installed guardrails (marketplace)
+  const installGuardrailUseCase = new InstallGuardrailUseCase(installedGuardrailRepo, pluginLoader, corePluginIds)
+  const uninstallGuardrailUseCase = new UninstallGuardrailUseCase(installedGuardrailRepo, corePluginIds)
+  const installedGuardrailRoutes = createInstalledGuardrailRoutes({ installGuardrailUseCase, uninstallGuardrailUseCase, installedGuardrailRepo, requireAuth })
+
   const container = {
     // Infrastructure
     orgRepo, workspaceRepo, conversationRepo, auditRepo, modelRepo, promptTemplateRepo,
@@ -356,8 +388,9 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
     testMcpConnectionUseCase, saveMcpConnectionUseCase, bindConsumerChannelUseCase, connectConsumerUseCase,
     executeQueryUseCase, routeMessageUseCase, manageQueuesUseCase, savePromptUseCase,
     managePoliciesUseCase, getSecurityOverviewUseCase, createPolicyOverrideUseCase,
+    installGuardrailUseCase, uninstallGuardrailUseCase,
     // Routes
-    authRoutes, orgRoutes, workspaceRoutes, conversationRoutes, connectorRoutes, queryRoutes, queueRoutes, routeRoutes, promptRoutes, guardrailPolicyRoutes,
+    authRoutes, orgRoutes, workspaceRoutes, conversationRoutes, connectorRoutes, queryRoutes, queueRoutes, routeRoutes, promptRoutes, guardrailPolicyRoutes, installedGuardrailRoutes,
   }
 
   return container

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -594,6 +594,44 @@ const migrations: Migration[] = [
       `);
     },
   },
+  {
+    version: 20,
+    name: 'guardrail policies table',
+    up: async (pool) => {
+      await pool.execute(`
+        CREATE TABLE IF NOT EXISTS guardrail_policies (
+          id VARCHAR(64) PRIMARY KEY,
+          org_id VARCHAR(64) NOT NULL,
+          plugin_id VARCHAR(64) NOT NULL,
+          enforcement ENUM('mandatory', 'recommended', 'off') NOT NULL DEFAULT 'off',
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+          updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+          UNIQUE KEY idx_org_plugin (org_id, plugin_id),
+          FOREIGN KEY (org_id) REFERENCES organisations(id) ON DELETE CASCADE
+        )
+      `);
+    },
+  },
+  {
+    version: 21,
+    name: 'guardrail policy overrides table',
+    up: async (pool) => {
+      await pool.execute(`
+        CREATE TABLE IF NOT EXISTS guardrail_policy_overrides (
+          id VARCHAR(64) PRIMARY KEY,
+          policy_id VARCHAR(64) NOT NULL,
+          workspace_id VARCHAR(64) NOT NULL,
+          justification TEXT NOT NULL,
+          created_by VARCHAR(64) NOT NULL,
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+          UNIQUE KEY idx_policy_workspace (policy_id, workspace_id),
+          FOREIGN KEY (policy_id) REFERENCES guardrail_policies(id) ON DELETE CASCADE,
+          FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
+          FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE
+        )
+      `);
+    },
+  },
 ];
 
 interface SchemaMigrationRow extends mysql.RowDataPacket {

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -632,6 +632,27 @@ const migrations: Migration[] = [
       `);
     },
   },
+  {
+    version: 22,
+    name: 'installed guardrails table',
+    up: async (pool) => {
+      await pool.execute(`
+        CREATE TABLE IF NOT EXISTS installed_guardrails (
+          id VARCHAR(64) PRIMARY KEY,
+          org_id VARCHAR(64) NOT NULL,
+          plugin_id VARCHAR(100) NOT NULL,
+          package_name VARCHAR(255) NOT NULL,
+          package_version VARCHAR(50) NOT NULL,
+          plugin_metadata JSON NOT NULL,
+          installed_by VARCHAR(64) NOT NULL,
+          installed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+          UNIQUE KEY idx_org_plugin (org_id, plugin_id),
+          FOREIGN KEY (org_id) REFERENCES organisations(id) ON DELETE CASCADE,
+          FOREIGN KEY (installed_by) REFERENCES users(id) ON DELETE CASCADE
+        )
+      `);
+    },
+  },
 ];
 
 interface SchemaMigrationRow extends mysql.RowDataPacket {

--- a/src/domain/guardrail/installedGuardrailRepository.ts
+++ b/src/domain/guardrail/installedGuardrailRepository.ts
@@ -1,0 +1,26 @@
+export interface PluginMetadata {
+  name: string
+  description: string
+  author: string
+  version: string
+  stage: string
+  configSchema: { fields: Array<{ name: string; label: string; type: string; required?: boolean; placeholder?: string; helpText?: string; options?: Array<{ value: string; label: string }>; defaultValue?: string | boolean | number }> }
+}
+
+export interface InstalledGuardrailData {
+  id: string
+  org_id: string
+  plugin_id: string
+  package_name: string
+  package_version: string
+  plugin_metadata: PluginMetadata
+  installed_by: string
+  installed_at?: string
+}
+
+export interface InstalledGuardrailRepository {
+  findByOrg(orgId: string): Promise<InstalledGuardrailData[]>
+  findByOrgAndPlugin(orgId: string, pluginId: string): Promise<InstalledGuardrailData | null>
+  install(data: InstalledGuardrailData): Promise<void>
+  uninstall(orgId: string, pluginId: string): Promise<void>
+}

--- a/src/domain/guardrail/policyRepository.ts
+++ b/src/domain/guardrail/policyRepository.ts
@@ -1,0 +1,53 @@
+export type PolicyEnforcement = 'mandatory' | 'recommended' | 'off'
+
+export interface GuardrailPolicyData {
+  id: string
+  org_id: string
+  plugin_id: string
+  enforcement: PolicyEnforcement
+  created_at?: string
+  updated_at?: string
+}
+
+export interface GuardrailPolicyOverrideData {
+  id: string
+  policy_id: string
+  workspace_id: string
+  justification: string
+  created_by: string
+  created_at?: string
+}
+
+export interface PolicyComplianceRow {
+  workspace_id: string
+  workspace_name: string
+  enabled: boolean
+  has_override: boolean
+}
+
+export interface SecurityOverviewStats {
+  total_events: number
+  blocked_events: number
+  stripped_events: number
+  flagged_events: number
+  events_by_day: Array<{ date: string; blocked: number; stripped: number }>
+  top_workspaces: Array<{ workspace_id: string; workspace_name: string; event_count: number }>
+  recent_flagged: Array<{ id: string; workspace_id: string; workspace_name: string; event_type: string; plugin_id: string; status: string; created_at: string }>
+  compliance_score: number
+  total_workspaces: number
+  compliant_workspaces: number
+}
+
+export interface GuardrailPolicyRepository {
+  listByOrg(orgId: string): Promise<GuardrailPolicyData[]>
+  findByOrgAndPlugin(orgId: string, pluginId: string): Promise<GuardrailPolicyData | null>
+  upsert(data: GuardrailPolicyData): Promise<void>
+  getComplianceForPolicy(policyId: string, pluginId: string, orgId: string): Promise<PolicyComplianceRow[]>
+  findOverride(policyId: string, workspaceId: string): Promise<GuardrailPolicyOverrideData | null>
+  createOverride(data: GuardrailPolicyOverrideData): Promise<void>
+  deleteOverride(policyId: string, workspaceId: string): Promise<void>
+  getOrgEventStats(orgId: string, days: number): Promise<SecurityOverviewStats>
+  findMandatoryPlugins(orgId: string): Promise<string[]>
+  findRecommendedPlugins(orgId: string): Promise<string[]>
+  findOverridesForWorkspace(workspaceId: string): Promise<Array<{ plugin_id: string }>>
+}

--- a/src/infrastructure/guard/PreQueryGuardDepsImpl.ts
+++ b/src/infrastructure/guard/PreQueryGuardDepsImpl.ts
@@ -1,0 +1,71 @@
+import type mysql from 'mysql2/promise'
+import type { PreQueryGuardDeps, GuardrailConfig } from '../../application/query/PreQueryGuardService.js'
+import Redis from 'ioredis'
+
+interface SpendRow extends mysql.RowDataPacket {
+  total: number
+}
+
+interface ConfigRow extends mysql.RowDataPacket {
+  config: string | null
+}
+
+export class PreQueryGuardDepsImpl implements PreQueryGuardDeps {
+  private redis: Redis | null = null
+
+  constructor(
+    private readonly pool: mysql.Pool,
+    private readonly redisHost?: string,
+    private readonly redisPort?: number,
+  ) {
+    if (redisHost && redisPort) {
+      this.redis = new Redis({ host: redisHost, port: redisPort, maxRetriesPerRequest: 1, lazyConnect: true })
+      this.redis.connect().catch(() => { this.redis = null })
+    }
+  }
+
+  async getMonthlySpend(workspaceId: string): Promise<number> {
+    const [rows] = await this.pool.execute<SpendRow[]>(
+      `SELECT COALESCE(SUM(cost_usd), 0) AS total FROM audit_logs WHERE workspace_id = ? AND created_at >= DATE_FORMAT(NOW(), '%Y-%m-01')`,
+      [workspaceId],
+    )
+    return Number(rows[0]?.total ?? 0)
+  }
+
+  async getWorkspaceGuardrailConfig(workspaceId: string): Promise<GuardrailConfig | null> {
+    // Read the merged config from all enabled workspace guardrails.
+    // Individual guardrail configs may contain cost_cap, rate_limit, or blocked_topics.
+    const [rows] = await this.pool.execute<ConfigRow[]>(
+      `SELECT config FROM workspace_guardrails WHERE workspace_id = ? AND enabled = TRUE AND config IS NOT NULL`,
+      [workspaceId],
+    )
+    if (rows.length === 0) return null
+
+    const merged: GuardrailConfig = {}
+    for (const row of rows) {
+      if (!row.config) continue
+      try {
+        const cfg = typeof row.config === 'string' ? JSON.parse(row.config) : row.config
+        if (cfg.cost_cap_monthly_usd != null) merged.cost_cap_monthly_usd = cfg.cost_cap_monthly_usd
+        if (cfg.rate_limit) merged.rate_limit = { ...merged.rate_limit, ...cfg.rate_limit }
+        if (cfg.blocked_topics) merged.blocked_topics = [...(merged.blocked_topics || []), ...cfg.blocked_topics]
+      } catch { /* skip invalid JSON */ }
+    }
+    return Object.keys(merged).length > 0 ? merged : null
+  }
+
+  async getRecentQueryCount(scope: string, windowSeconds: number): Promise<number> {
+    if (!this.redis) return 0
+    const key = `ratelimit:${scope}`
+    try {
+      const count = await this.redis.incr(key)
+      if (count === 1) {
+        await this.redis.expire(key, windowSeconds)
+      }
+      // We incremented for the current request; return count - 1 to reflect "before this request"
+      return count - 1
+    } catch {
+      return 0
+    }
+  }
+}

--- a/src/infrastructure/persistence/mysql/MysqlGuardrailPolicyRepository.ts
+++ b/src/infrastructure/persistence/mysql/MysqlGuardrailPolicyRepository.ts
@@ -1,0 +1,305 @@
+import type mysql from 'mysql2/promise'
+import type {
+  GuardrailPolicyRepository,
+  GuardrailPolicyData,
+  GuardrailPolicyOverrideData,
+  PolicyComplianceRow,
+  SecurityOverviewStats,
+} from '../../../domain/guardrail/policyRepository.js'
+
+interface PolicyRow extends mysql.RowDataPacket {
+  id: string
+  org_id: string
+  plugin_id: string
+  enforcement: string
+  created_at: string
+  updated_at: string
+}
+
+interface OverrideRow extends mysql.RowDataPacket {
+  id: string
+  policy_id: string
+  workspace_id: string
+  justification: string
+  created_by: string
+  created_at: string
+}
+
+interface ComplianceRow extends mysql.RowDataPacket {
+  workspace_id: string
+  workspace_name: string
+  enabled: number
+  has_override: number
+}
+
+interface CountRow extends mysql.RowDataPacket {
+  total: number
+}
+
+interface EventCountRow extends mysql.RowDataPacket {
+  blocked_events: number
+  stripped_events: number
+  flagged_events: number
+}
+
+interface DayRow extends mysql.RowDataPacket {
+  date: string
+  blocked: number
+  stripped: number
+}
+
+interface TopWorkspaceRow extends mysql.RowDataPacket {
+  workspace_id: string
+  workspace_name: string
+  event_count: number
+}
+
+interface FlaggedRow extends mysql.RowDataPacket {
+  id: string
+  workspace_id: string
+  workspace_name: string
+  event_type: string
+  plugin_id: string
+  status: string
+  created_at: string
+}
+
+interface PluginRow extends mysql.RowDataPacket {
+  plugin_id: string
+}
+
+interface OverridePluginRow extends mysql.RowDataPacket {
+  plugin_id: string
+}
+
+export class MysqlGuardrailPolicyRepository implements GuardrailPolicyRepository {
+  constructor(private readonly pool: mysql.Pool) {}
+
+  async listByOrg(orgId: string): Promise<GuardrailPolicyData[]> {
+    const [rows] = await this.pool.execute<PolicyRow[]>(
+      'SELECT * FROM guardrail_policies WHERE org_id = ? ORDER BY plugin_id',
+      [orgId],
+    )
+    return rows.map(mapPolicyRow)
+  }
+
+  async findByOrgAndPlugin(orgId: string, pluginId: string): Promise<GuardrailPolicyData | null> {
+    const [rows] = await this.pool.execute<PolicyRow[]>(
+      'SELECT * FROM guardrail_policies WHERE org_id = ? AND plugin_id = ? LIMIT 1',
+      [orgId, pluginId],
+    )
+    return rows[0] ? mapPolicyRow(rows[0]) : null
+  }
+
+  async upsert(data: GuardrailPolicyData): Promise<void> {
+    await this.pool.execute(
+      `INSERT INTO guardrail_policies (id, org_id, plugin_id, enforcement)
+       VALUES (?, ?, ?, ?)
+       ON DUPLICATE KEY UPDATE enforcement = VALUES(enforcement)`,
+      [data.id, data.org_id, data.plugin_id, data.enforcement],
+    )
+  }
+
+  async getComplianceForPolicy(policyId: string, pluginId: string, orgId: string): Promise<PolicyComplianceRow[]> {
+    const [rows] = await this.pool.execute<ComplianceRow[]>(
+      `SELECT
+         w.id AS workspace_id,
+         w.name AS workspace_name,
+         CASE WHEN wg.id IS NOT NULL AND wg.enabled = 1 THEN 1 ELSE 0 END AS enabled,
+         CASE WHEN gpo.id IS NOT NULL THEN 1 ELSE 0 END AS has_override
+       FROM workspaces w
+       LEFT JOIN workspace_guardrails wg ON wg.workspace_id = w.id AND wg.guardrail_id = ?
+       LEFT JOIN guardrail_policy_overrides gpo ON gpo.policy_id = ? AND gpo.workspace_id = w.id
+       WHERE w.org_id = ? AND w.status != 'archived'
+       ORDER BY w.name`,
+      [pluginId, policyId, orgId],
+    )
+    return rows.map(r => ({
+      workspace_id: r.workspace_id,
+      workspace_name: r.workspace_name,
+      enabled: r.enabled === 1,
+      has_override: r.has_override === 1,
+    }))
+  }
+
+  async findOverride(policyId: string, workspaceId: string): Promise<GuardrailPolicyOverrideData | null> {
+    const [rows] = await this.pool.execute<OverrideRow[]>(
+      'SELECT * FROM guardrail_policy_overrides WHERE policy_id = ? AND workspace_id = ? LIMIT 1',
+      [policyId, workspaceId],
+    )
+    return rows[0] ? mapOverrideRow(rows[0]) : null
+  }
+
+  async createOverride(data: GuardrailPolicyOverrideData): Promise<void> {
+    await this.pool.execute(
+      'INSERT INTO guardrail_policy_overrides (id, policy_id, workspace_id, justification, created_by) VALUES (?, ?, ?, ?, ?)',
+      [data.id, data.policy_id, data.workspace_id, data.justification, data.created_by],
+    )
+  }
+
+  async deleteOverride(policyId: string, workspaceId: string): Promise<void> {
+    await this.pool.execute(
+      'DELETE FROM guardrail_policy_overrides WHERE policy_id = ? AND workspace_id = ?',
+      [policyId, workspaceId],
+    )
+  }
+
+  async getOrgEventStats(orgId: string, days: number): Promise<SecurityOverviewStats> {
+    const dateCutoff = `DATE_SUB(NOW(), INTERVAL ${days} DAY)`
+
+    // All these queries join through workspaces to scope by org_id
+    const [
+      [eventCounts],
+      [dayRows],
+      [topWorkspaces],
+      [flaggedRows],
+      [wsCountRows],
+      [compliantRows],
+    ] = await Promise.all([
+      this.pool.execute<EventCountRow[]>(
+        `SELECT
+           SUM(CASE WHEN ge.event_type = 'execution_blocked' THEN 1 ELSE 0 END) AS blocked_events,
+           SUM(CASE WHEN ge.event_type = 'retrieval_stripped' THEN 1 ELSE 0 END) AS stripped_events,
+           SUM(CASE WHEN ge.status = 'flagged' THEN 1 ELSE 0 END) AS flagged_events
+         FROM guardrail_events ge
+         JOIN workspaces w ON w.id = ge.workspace_id
+         WHERE w.org_id = ? AND ge.created_at >= ${dateCutoff}`,
+        [orgId],
+      ),
+      this.pool.execute<DayRow[]>(
+        `SELECT
+           DATE(ge.created_at) AS date,
+           SUM(CASE WHEN ge.event_type = 'execution_blocked' THEN 1 ELSE 0 END) AS blocked,
+           SUM(CASE WHEN ge.event_type = 'retrieval_stripped' THEN 1 ELSE 0 END) AS stripped
+         FROM guardrail_events ge
+         JOIN workspaces w ON w.id = ge.workspace_id
+         WHERE w.org_id = ? AND ge.created_at >= ${dateCutoff}
+         GROUP BY DATE(ge.created_at)
+         ORDER BY date`,
+        [orgId],
+      ),
+      this.pool.execute<TopWorkspaceRow[]>(
+        `SELECT ge.workspace_id, w.name AS workspace_name, COUNT(*) AS event_count
+         FROM guardrail_events ge
+         JOIN workspaces w ON w.id = ge.workspace_id
+         WHERE w.org_id = ? AND ge.created_at >= ${dateCutoff}
+         GROUP BY ge.workspace_id, w.name
+         ORDER BY event_count DESC
+         LIMIT 5`,
+        [orgId],
+      ),
+      this.pool.execute<FlaggedRow[]>(
+        `SELECT ge.id, ge.workspace_id, w.name AS workspace_name, ge.event_type, ge.plugin_id, ge.status, ge.created_at
+         FROM guardrail_events ge
+         JOIN workspaces w ON w.id = ge.workspace_id
+         WHERE w.org_id = ? AND ge.status = 'flagged'
+         ORDER BY ge.created_at DESC
+         LIMIT 10`,
+        [orgId],
+      ),
+      this.pool.execute<CountRow[]>(
+        `SELECT COUNT(*) AS total FROM workspaces WHERE org_id = ? AND status != 'archived'`,
+        [orgId],
+      ),
+      this.pool.execute<CountRow[]>(
+        `SELECT COUNT(DISTINCT w.id) AS total
+         FROM workspaces w
+         WHERE w.org_id = ? AND w.status != 'archived'
+         AND NOT EXISTS (
+           SELECT 1 FROM guardrail_policies gp
+           WHERE gp.org_id = ? AND gp.enforcement = 'mandatory'
+           AND NOT EXISTS (
+             SELECT 1 FROM workspace_guardrails wg
+             WHERE wg.workspace_id = w.id AND wg.guardrail_id = gp.plugin_id AND wg.enabled = 1
+           )
+         )`,
+        [orgId, orgId],
+      ),
+    ])
+
+    const ec = eventCounts[0]
+    const blocked = Number(ec?.blocked_events ?? 0)
+    const stripped = Number(ec?.stripped_events ?? 0)
+    const flagged = Number(ec?.flagged_events ?? 0)
+    const totalWs = Number(wsCountRows[0]?.total ?? 0)
+    const compliantWs = Number(compliantRows[0]?.total ?? 0)
+
+    return {
+      total_events: blocked + stripped,
+      blocked_events: blocked,
+      stripped_events: stripped,
+      flagged_events: flagged,
+      events_by_day: dayRows.map(r => ({
+        date: typeof r.date === 'string' ? r.date : String(r.date),
+        blocked: Number(r.blocked),
+        stripped: Number(r.stripped),
+      })),
+      top_workspaces: topWorkspaces.map(r => ({
+        workspace_id: r.workspace_id,
+        workspace_name: r.workspace_name,
+        event_count: Number(r.event_count),
+      })),
+      recent_flagged: flaggedRows.map(r => ({
+        id: r.id,
+        workspace_id: r.workspace_id,
+        workspace_name: r.workspace_name,
+        event_type: r.event_type,
+        plugin_id: r.plugin_id,
+        status: r.status,
+        created_at: r.created_at,
+      })),
+      compliance_score: totalWs > 0 ? Math.round((compliantWs / totalWs) * 100) : 100,
+      total_workspaces: totalWs,
+      compliant_workspaces: compliantWs,
+    }
+  }
+
+  async findMandatoryPlugins(orgId: string): Promise<string[]> {
+    const [rows] = await this.pool.execute<PluginRow[]>(
+      `SELECT plugin_id FROM guardrail_policies WHERE org_id = ? AND enforcement = 'mandatory'`,
+      [orgId],
+    )
+    return rows.map(r => r.plugin_id)
+  }
+
+  async findRecommendedPlugins(orgId: string): Promise<string[]> {
+    const [rows] = await this.pool.execute<PluginRow[]>(
+      `SELECT plugin_id FROM guardrail_policies WHERE org_id = ? AND enforcement = 'recommended'`,
+      [orgId],
+    )
+    return rows.map(r => r.plugin_id)
+  }
+
+  async findOverridesForWorkspace(workspaceId: string): Promise<Array<{ plugin_id: string }>> {
+    const [rows] = await this.pool.execute<OverridePluginRow[]>(
+      `SELECT gp.plugin_id
+       FROM guardrail_policy_overrides gpo
+       JOIN guardrail_policies gp ON gp.id = gpo.policy_id
+       WHERE gpo.workspace_id = ?`,
+      [workspaceId],
+    )
+    return rows.map(r => ({ plugin_id: r.plugin_id }))
+  }
+}
+
+function mapPolicyRow(r: PolicyRow): GuardrailPolicyData {
+  return {
+    id: r.id,
+    org_id: r.org_id,
+    plugin_id: r.plugin_id,
+    enforcement: r.enforcement as GuardrailPolicyData['enforcement'],
+    created_at: r.created_at,
+    updated_at: r.updated_at,
+  }
+}
+
+function mapOverrideRow(r: OverrideRow): GuardrailPolicyOverrideData {
+  return {
+    id: r.id,
+    policy_id: r.policy_id,
+    workspace_id: r.workspace_id,
+    justification: r.justification,
+    created_by: r.created_by,
+    created_at: r.created_at,
+  }
+}

--- a/src/infrastructure/persistence/mysql/MysqlInstalledGuardrailRepository.ts
+++ b/src/infrastructure/persistence/mysql/MysqlInstalledGuardrailRepository.ts
@@ -1,0 +1,65 @@
+import type mysql from 'mysql2/promise'
+import type { InstalledGuardrailRepository, InstalledGuardrailData, PluginMetadata } from '../../../domain/guardrail/installedGuardrailRepository.js'
+
+interface InstalledRow extends mysql.RowDataPacket {
+  id: string
+  org_id: string
+  plugin_id: string
+  package_name: string
+  package_version: string
+  plugin_metadata: string | PluginMetadata
+  installed_by: string
+  installed_at: string
+}
+
+export class MysqlInstalledGuardrailRepository implements InstalledGuardrailRepository {
+  constructor(private readonly pool: mysql.Pool) {}
+
+  async findByOrg(orgId: string): Promise<InstalledGuardrailData[]> {
+    const [rows] = await this.pool.execute<InstalledRow[]>(
+      'SELECT * FROM installed_guardrails WHERE org_id = ? ORDER BY installed_at DESC',
+      [orgId],
+    )
+    return rows.map(mapRow)
+  }
+
+  async findByOrgAndPlugin(orgId: string, pluginId: string): Promise<InstalledGuardrailData | null> {
+    const [rows] = await this.pool.execute<InstalledRow[]>(
+      'SELECT * FROM installed_guardrails WHERE org_id = ? AND plugin_id = ? LIMIT 1',
+      [orgId, pluginId],
+    )
+    return rows[0] ? mapRow(rows[0]) : null
+  }
+
+  async install(data: InstalledGuardrailData): Promise<void> {
+    await this.pool.execute(
+      'INSERT INTO installed_guardrails (id, org_id, plugin_id, package_name, package_version, plugin_metadata, installed_by) VALUES (?, ?, ?, ?, ?, ?, ?)',
+      [data.id, data.org_id, data.plugin_id, data.package_name, data.package_version, JSON.stringify(data.plugin_metadata), data.installed_by],
+    )
+  }
+
+  async uninstall(orgId: string, pluginId: string): Promise<void> {
+    await this.pool.execute(
+      'DELETE FROM installed_guardrails WHERE org_id = ? AND plugin_id = ?',
+      [orgId, pluginId],
+    )
+  }
+}
+
+function parseMetadata(raw: string | PluginMetadata): PluginMetadata {
+  if (typeof raw === 'object') return raw
+  try { return JSON.parse(raw) } catch { return { name: '', description: '', author: '', version: '', stage: '', configSchema: { fields: [] } } }
+}
+
+function mapRow(r: InstalledRow): InstalledGuardrailData {
+  return {
+    id: r.id,
+    org_id: r.org_id,
+    plugin_id: r.plugin_id,
+    package_name: r.package_name,
+    package_version: r.package_version,
+    plugin_metadata: parseMetadata(r.plugin_metadata),
+    installed_by: r.installed_by,
+    installed_at: r.installed_at,
+  }
+}

--- a/src/infrastructure/plugins/DynamicPluginLoader.ts
+++ b/src/infrastructure/plugins/DynamicPluginLoader.ts
@@ -1,0 +1,45 @@
+import type { PluginLoader, LoadedPlugin } from '../../application/ports/PluginLoader.js'
+import pino from 'pino'
+
+const log = pino({ name: 'plugin-loader' })
+
+/**
+ * Loads guardrail plugins from npm packages via dynamic import.
+ *
+ * The package must be pre-installed on the server (in node_modules).
+ * It must export a default or named `plugin` export that implements
+ * one of the guardrail plugin interfaces.
+ */
+export class DynamicPluginLoader implements PluginLoader {
+  async load(packageName: string): Promise<LoadedPlugin | null> {
+    try {
+      const mod = await import(packageName)
+      const instance = mod.default || mod.plugin
+      if (!instance || typeof instance !== 'object') {
+        log.warn({ packageName }, 'Package does not export a plugin instance')
+        return null
+      }
+
+      if (!instance.id || !instance.name || !instance.stage) {
+        log.warn({ packageName }, 'Plugin instance missing required fields (id, name, stage)')
+        return null
+      }
+
+      return {
+        plugin_id: instance.id,
+        metadata: {
+          name: instance.name,
+          description: instance.description || '',
+          author: instance.author || '',
+          version: instance.version || '0.0.0',
+          stage: instance.stage,
+          configSchema: instance.configSchema || { fields: [] },
+        },
+        instance,
+      }
+    } catch (err) {
+      log.error({ packageName, error: (err as Error).message }, 'Failed to load plugin package')
+      return null
+    }
+  }
+}

--- a/src/presentation/routes/guardrailPolicies.ts
+++ b/src/presentation/routes/guardrailPolicies.ts
@@ -1,0 +1,97 @@
+import { Hono } from 'hono'
+import { z } from 'zod'
+import type { ManagePoliciesUseCase } from '../../application/guardrail/ManagePoliciesUseCase.js'
+import type { GetSecurityOverviewUseCase } from '../../application/guardrail/GetSecurityOverviewUseCase.js'
+import type { CreatePolicyOverrideUseCase } from '../../application/guardrail/CreatePolicyOverrideUseCase.js'
+import { parseBody } from '../middleware/validate.js'
+import type { AuthUser, AuthEnv } from '../middleware/auth.js'
+import { NotFoundError, ConflictError, ValidationError } from '../../domain/shared/errors.js'
+
+const setEnforcementSchema = z.object({
+  enforcement: z.enum(['mandatory', 'recommended', 'off']),
+})
+
+const createOverrideSchema = z.object({
+  workspace_id: z.string().min(1).max(64),
+  justification: z.string().min(1).max(2000),
+})
+
+interface GuardrailPolicyRouteDeps {
+  managePoliciesUseCase: ManagePoliciesUseCase
+  getSecurityOverviewUseCase: GetSecurityOverviewUseCase
+  createPolicyOverrideUseCase: CreatePolicyOverrideUseCase
+  requireAuth: (c: import('hono').Context, next: import('hono').Next) => Promise<Response | void>
+}
+
+export function createGuardrailPolicyRoutes(deps: GuardrailPolicyRouteDeps) {
+  const policies = new Hono<AuthEnv>()
+
+  policies.use('/api/guardrail-policies/*', deps.requireAuth)
+  policies.use('/api/guardrail-policies', deps.requireAuth)
+  policies.use('/api/security-overview', deps.requireAuth)
+
+  // GET /api/security-overview - org-wide security pulse
+  policies.get('/api/security-overview', async (c) => {
+    const user = c.get('user') as AuthUser
+    const days = parseInt(c.req.query('days') || '30', 10)
+    const result = await deps.getSecurityOverviewUseCase.execute(user.org_id, days)
+    return c.json(result)
+  })
+
+  // GET /api/guardrail-policies - list all policies for the org
+  policies.get('/api/guardrail-policies', async (c) => {
+    const user = c.get('user') as AuthUser
+    const result = await deps.managePoliciesUseCase.listPolicies(user.org_id)
+    return c.json({ policies: result })
+  })
+
+  // PUT /api/guardrail-policies/:pluginId - set enforcement level
+  policies.put('/api/guardrail-policies/:pluginId', async (c) => {
+    const user = c.get('user') as AuthUser
+    const pluginId = c.req.param('pluginId')
+    const body = await parseBody(c, setEnforcementSchema)
+    if (!body.success) return body.response
+
+    try {
+      await deps.managePoliciesUseCase.setEnforcement(user.org_id, pluginId, body.data.enforcement)
+      return c.json({ status: 'ok' })
+    } catch (err) {
+      if (err instanceof ValidationError) return c.json({ error: err.message }, 400)
+      throw err
+    }
+  })
+
+  // GET /api/guardrail-policies/:pluginId/compliance - workspace compliance for a policy
+  policies.get('/api/guardrail-policies/:pluginId/compliance', async (c) => {
+    const user = c.get('user') as AuthUser
+    const pluginId = c.req.param('pluginId')
+    const result = await deps.managePoliciesUseCase.getCompliance(user.org_id, pluginId)
+    return c.json({ compliance: result })
+  })
+
+  // POST /api/guardrail-policies/:pluginId/override - workspace admin justifies disabling a recommended policy
+  policies.post('/api/guardrail-policies/:pluginId/override', async (c) => {
+    const user = c.get('user') as AuthUser
+    const pluginId = c.req.param('pluginId')
+    const body = await parseBody(c, createOverrideSchema)
+    if (!body.success) return body.response
+
+    try {
+      await deps.createPolicyOverrideUseCase.execute({
+        orgId: user.org_id,
+        pluginId,
+        workspaceId: body.data.workspace_id,
+        justification: body.data.justification,
+        userId: user.id,
+      })
+      return c.json({ status: 'ok' })
+    } catch (err) {
+      if (err instanceof ValidationError) return c.json({ error: err.message }, 400)
+      if (err instanceof NotFoundError) return c.json({ error: 'policy_not_found' }, 404)
+      if (err instanceof ConflictError) return c.json({ error: err.message }, 409)
+      throw err
+    }
+  })
+
+  return policies
+}

--- a/src/presentation/routes/installedGuardrails.ts
+++ b/src/presentation/routes/installedGuardrails.ts
@@ -1,0 +1,66 @@
+import { Hono } from 'hono'
+import { z } from 'zod'
+import type { InstallGuardrailUseCase } from '../../application/guardrail/InstallGuardrailUseCase.js'
+import type { UninstallGuardrailUseCase } from '../../application/guardrail/UninstallGuardrailUseCase.js'
+import type { InstalledGuardrailRepository } from '../../domain/guardrail/installedGuardrailRepository.js'
+import { parseBody } from '../middleware/validate.js'
+import type { AuthUser, AuthEnv } from '../middleware/auth.js'
+import { NotFoundError, ConflictError, ValidationError } from '../../domain/shared/errors.js'
+
+const installSchema = z.object({
+  package_name: z.string().min(1).max(255),
+})
+
+interface InstalledGuardrailRouteDeps {
+  installGuardrailUseCase: InstallGuardrailUseCase
+  uninstallGuardrailUseCase: UninstallGuardrailUseCase
+  installedGuardrailRepo: InstalledGuardrailRepository
+  requireAuth: (c: import('hono').Context, next: import('hono').Next) => Promise<Response | void>
+}
+
+export function createInstalledGuardrailRoutes(deps: InstalledGuardrailRouteDeps) {
+  const routes = new Hono<AuthEnv>()
+
+  routes.use('/api/installed-guardrails/*', deps.requireAuth)
+  routes.use('/api/installed-guardrails', deps.requireAuth)
+
+  // List installed marketplace guardrails for the org
+  routes.get('/api/installed-guardrails', async (c) => {
+    const user = c.get('user') as AuthUser
+    const installed = await deps.installedGuardrailRepo.findByOrg(user.org_id)
+    return c.json({ installedGuardrails: installed })
+  })
+
+  // Install a marketplace guardrail
+  routes.post('/api/installed-guardrails', async (c) => {
+    const user = c.get('user') as AuthUser
+    const body = await parseBody(c, installSchema)
+    if (!body.success) return body.response
+
+    try {
+      const result = await deps.installGuardrailUseCase.execute(user.org_id, user.id, body.data.package_name)
+      return c.json({ guardrail: result })
+    } catch (err) {
+      if (err instanceof ValidationError) return c.json({ error: err.message }, 400)
+      if (err instanceof ConflictError) return c.json({ error: err.message }, 409)
+      throw err
+    }
+  })
+
+  // Uninstall a marketplace guardrail
+  routes.delete('/api/installed-guardrails/:pluginId', async (c) => {
+    const user = c.get('user') as AuthUser
+    const pluginId = c.req.param('pluginId')
+
+    try {
+      await deps.uninstallGuardrailUseCase.execute(user.org_id, pluginId)
+      return c.json({ status: 'ok' })
+    } catch (err) {
+      if (err instanceof ValidationError) return c.json({ error: err.message }, 400)
+      if (err instanceof NotFoundError) return c.json({ error: 'not_found' }, 404)
+      throw err
+    }
+  })
+
+  return routes
+}

--- a/src/presentation/routes/workspaces.ts
+++ b/src/presentation/routes/workspaces.ts
@@ -13,6 +13,7 @@ import type { GetConnectionsUseCase } from '../../application/workspace/GetConne
 import type { GetKnowledgeUseCase } from '../../application/workspace/GetKnowledgeUseCase.js'
 import type { GetComplianceUseCase } from '../../application/workspace/GetComplianceUseCase.js'
 import type { GuardrailEventRepository } from '../../domain/guardrail/repository.js'
+import type { GuardrailPolicyRepository } from '../../domain/guardrail/policyRepository.js'
 import type { OrganisationRepository } from '../../domain/organisation/repository.js'
 import type { WorkspaceRepository } from '../../domain/workspace/repository.js'
 import type { TenantService } from '../../application/ports/TenantService.js'
@@ -55,6 +56,7 @@ interface WorkspaceRouteDeps {
   getKnowledgeUseCase: GetKnowledgeUseCase
   getComplianceUseCase: GetComplianceUseCase
   guardrailEventRepo: GuardrailEventRepository
+  guardrailPolicyRepo: GuardrailPolicyRepository
   listAvailableGuardrails: () => Array<{ id: string; name: string; description: string; stage: string; configSchema: { fields: Array<{ name: string; label: string; type: string; required?: boolean; placeholder?: string; helpText?: string; options?: Array<{ value: string; label: string }>; defaultValue?: string | boolean | number }> } }>
   orgRepo: OrganisationRepository
   workspaceRepo: WorkspaceRepository
@@ -160,9 +162,11 @@ export function createWorkspaceRoutes(deps: WorkspaceRouteDeps) {
     const limit = c.req.query('limit')
 
     const hasFilter = eventType || eventStatus || search || page || limit
+    const validEventType = eventType === 'execution_blocked' || eventType === 'retrieval_stripped' ? eventType as 'execution_blocked' | 'retrieval_stripped' : undefined
+    const validStatus = eventStatus === 'open' || eventStatus === 'flagged' || eventStatus === 'dismissed' ? eventStatus as 'open' | 'flagged' | 'dismissed' : undefined
     const eventFilter = hasFilter ? {
-      event_type: eventType === 'execution_blocked' || eventType === 'retrieval_stripped' ? eventType : undefined,
-      status: eventStatus === 'open' || eventStatus === 'flagged' || eventStatus === 'dismissed' ? eventStatus : undefined,
+      event_type: validEventType,
+      status: validStatus,
       search: search || undefined,
       limit: limit ? Math.min(Math.max(parseInt(limit, 10) || 20, 1), 100) : 20,
       offset: page ? (Math.max(parseInt(page, 10) || 0, 0)) * (limit ? Math.min(Math.max(parseInt(limit, 10) || 20, 1), 100) : 20) : 0,
@@ -237,10 +241,15 @@ export function createWorkspaceRoutes(deps: WorkspaceRouteDeps) {
     const enabled = await deps.workspaceRepo.findEnabledGuardrailConfigs(workspaceId)
     const enabledIds = new Set(enabled.map(e => e.guardrail_id))
 
+    // Fetch org-level policy enforcement for each guardrail
+    const policies = await deps.guardrailPolicyRepo.listByOrg(user.org_id)
+    const policyMap = new Map(policies.map(p => [p.plugin_id, p.enforcement]))
+
     const guardrails = available.map(g => ({
       ...g,
       enabled: enabledIds.has(g.id),
       workspaceConfig: enabled.find(e => e.guardrail_id === g.id)?.config || null,
+      enforcement: policyMap.get(g.id) || null,
     }))
 
     return c.json({ guardrails })

--- a/src/presentation/routes/workspaces.ts
+++ b/src/presentation/routes/workspaces.ts
@@ -57,7 +57,7 @@ interface WorkspaceRouteDeps {
   getComplianceUseCase: GetComplianceUseCase
   guardrailEventRepo: GuardrailEventRepository
   guardrailPolicyRepo: GuardrailPolicyRepository
-  listAvailableGuardrails: () => Array<{ id: string; name: string; description: string; stage: string; configSchema: { fields: Array<{ name: string; label: string; type: string; required?: boolean; placeholder?: string; helpText?: string; options?: Array<{ value: string; label: string }>; defaultValue?: string | boolean | number }> } }>
+  listAvailableGuardrails: (orgId: string) => Promise<Array<{ id: string; name: string; description: string; stage: string; source: 'core' | 'marketplace'; configSchema: { fields: Array<{ name: string; label: string; type: string; required?: boolean; placeholder?: string; helpText?: string; options?: Array<{ value: string; label: string }>; defaultValue?: string | boolean | number }> } }>>
   orgRepo: OrganisationRepository
   workspaceRepo: WorkspaceRepository
   tenantService: TenantService
@@ -237,7 +237,7 @@ export function createWorkspaceRoutes(deps: WorkspaceRouteDeps) {
     const workspaceId = c.req.param('id')
     await guardWorkspace(workspaceId, user.org_id)
 
-    const available = deps.listAvailableGuardrails()
+    const available = await deps.listAvailableGuardrails(user.org_id)
     const enabled = await deps.workspaceRepo.findEnabledGuardrailConfigs(workspaceId)
     const enabledIds = new Set(enabled.map(e => e.guardrail_id))
 

--- a/src/shared/entities.ts
+++ b/src/shared/entities.ts
@@ -219,3 +219,25 @@ export interface OrgSetting {
   value: string;
   is_secret: boolean;
 }
+
+// ── Guardrail policies ──
+
+export type PolicyEnforcement = 'mandatory' | 'recommended' | 'off';
+
+export interface GuardrailPolicy {
+  id: string;
+  org_id: string;
+  plugin_id: string;
+  enforcement: PolicyEnforcement;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface GuardrailPolicyOverride {
+  id: string;
+  policy_id: string;
+  workspace_id: string;
+  justification: string;
+  created_by: string;
+  created_at: string;
+}


### PR DESCRIPTION
## Summary

Implements org-level guardrail policies (issue #88): the security room backbone.

- **Three enforcement levels**: mandatory (cannot be disabled), recommended (can be overridden with justification), off
- **Security overview endpoint**: org-wide event stats, compliance score, events by day, top workspaces, flagged events
- **Policy management**: list policies, set enforcement, view per-workspace compliance
- **Override system**: workspace admins can justify disabling recommended policies; mandatory policies cannot be overridden
- **Runtime enforcement**: `resolveGuardrails`, `resolveExecutionRails`, and `resolveRetrievalRails` now merge org-level policy decisions at query time
- **Workspace integration**: guardrails endpoint returns enforcement field for dashboard lock icons

### New API endpoints

| Method | Endpoint | Purpose |
|---|---|---|
| GET | `/api/security-overview` | Org-wide security pulse |
| GET | `/api/guardrail-policies` | List all policies for the org |
| PUT | `/api/guardrail-policies/:pluginId` | Set enforcement level |
| GET | `/api/guardrail-policies/:pluginId/compliance` | Workspace compliance for a policy |
| POST | `/api/guardrail-policies/:pluginId/override` | Workspace admin justifies disabling recommended policy |

### DDD layers

- **Domain**: `GuardrailPolicyRepository` interface, types (`PolicyEnforcement`, `SecurityOverviewStats`, etc.)
- **Application**: 3 use cases with 17 TDD tests (ManagePolicies, GetSecurityOverview, CreatePolicyOverride)
- **Infrastructure**: `MysqlGuardrailPolicyRepository`, migrations 20-21
- **Presentation**: `guardrailPolicies.ts` routes

## Test plan

- [x] 17 new unit tests (TDD red-green-refactor)
- [x] All 308 tests pass
- [x] TypeScript compiles cleanly
- [ ] Integration test with running DB (manual)
- [ ] Dashboard: policies tab, overview charts, lock icons (separate PR)
- [ ] SDK: add policy methods and types (separate PR)

Closes #88

## Cross-repo impact

| Repo | Status |
|---|---|
| supaproxy-server | This PR |
| supaproxy-sdk | Needs new policy methods and types |
| supaproxy-dashboard | Needs redesigned guardrails page |
| supaproxy-docs | Needs policy system documentation |

🤖 Generated with [Claude Code](https://claude.com/claude-code)