### PR TITLE
refactor: org-level consumers with entry points and routing

### DIFF
--- a/src/__tests__/mocks.ts
+++ b/src/__tests__/mocks.ts
@@ -3,6 +3,7 @@ import type { OrganisationRepository, UserData, OrgSettingData, TeamData } from 
 import type { WorkspaceRepository, WorkspaceData, ConnectionData, ConsumerData, WorkspaceStatsData, WorkspaceListItemData } from '../domain/workspace/repository.js'
 import type { ConversationRepository, ConversationData, ConversationStatsData as ConvStatsData, ConversationFilterData, ColdTransitionData } from '../domain/conversation/repository.js'
 import type { AuditLogRepository } from '../domain/audit/repository.js'
+import type { IntegrationRepository, EntryPointRepository } from '../domain/integration/repository.js'
 import type { PasswordService } from '../application/ports/PasswordService.js'
 import type { TokenService, TokenPayload } from '../application/ports/TokenService.js'
 import type { QueueService, QueueJobCounts } from '../application/ports/QueueService.js'
@@ -306,5 +307,27 @@ export function mockInstalledGuardrailRepo(): InstalledGuardrailRepository {
     findByOrgAndPlugin: vi.fn().mockResolvedValue(null),
     install: vi.fn().mockResolvedValue(undefined),
     uninstall: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+export function mockIntegrationRepo(): IntegrationRepository {
+  return {
+    findByOrg: vi.fn().mockResolvedValue([]),
+    findByOrgAndType: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue(undefined),
+    updateStatus: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+export function mockEntryPointRepo(): EntryPointRepository {
+  return {
+    findByIntegration: vi.fn().mockResolvedValue([]),
+    findByChannel: vi.fn().mockResolvedValue(null),
+    findById: vi.fn().mockResolvedValue(null),
+    create: vi.fn().mockResolvedValue(undefined),
+    update: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+    findByOrg: vi.fn().mockResolvedValue([]),
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -74,6 +74,7 @@ export function createApp(container: Container, corsOrigins?: string[]): Hono {
   app.route('/', container.promptRoutes)
   app.route('/', container.guardrailPolicyRoutes)
   app.route('/', container.installedGuardrailRoutes)
+  app.route('/', container.integrationRoutes)
 
   // WhatsApp webhook (no auth; Meta needs direct access)
   app.get('/api/webhooks/whatsapp', async (c) => {

--- a/src/application/guardrail/ManagePoliciesUseCase.test.ts
+++ b/src/application/guardrail/ManagePoliciesUseCase.test.ts
@@ -88,8 +88,8 @@ describe('ManagePoliciesUseCase', () => {
       const existing: GuardrailPolicyData = { id: 'p1', org_id: 'org-1', plugin_id: '@supaproxy/guardrails:pattern', enforcement: 'mandatory' }
       vi.mocked(policyRepo.findByOrgAndPlugin).mockResolvedValue(existing)
       vi.mocked(policyRepo.getComplianceForPolicy).mockResolvedValue([
-        { workspace_id: 'ws-1', workspace_name: 'General', enabled: true, has_override: false },
-        { workspace_id: 'ws-2', workspace_name: 'Sales', enabled: false, has_override: false },
+        { workspace_id: 'ws-1', workspace_name: 'General', enabled: true, has_override: false, is_default: true },
+        { workspace_id: 'ws-2', workspace_name: 'Sales', enabled: false, has_override: false, is_default: false },
       ])
 
       const result = await useCase.getCompliance('org-1', '@supaproxy/guardrails:pattern')

--- a/src/application/integration/ManageEntryPointUseCase.test.ts
+++ b/src/application/integration/ManageEntryPointUseCase.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ManageEntryPointUseCase } from './ManageEntryPointUseCase.js'
+import { mockIntegrationRepo, mockEntryPointRepo } from '../../__tests__/mocks.js'
+import type { EntryPointData } from '../../domain/integration/repository.js'
+
+describe('ManageEntryPointUseCase', () => {
+  function setup() {
+    const integrationRepo = mockIntegrationRepo()
+    const entryPointRepo = mockEntryPointRepo()
+    const useCase = new ManageEntryPointUseCase(integrationRepo, entryPointRepo)
+    return { integrationRepo, entryPointRepo, useCase }
+  }
+
+  describe('listEntryPoints', () => {
+    it('returns entry points for an integration', async () => {
+      const { entryPointRepo, useCase } = setup()
+      const eps: EntryPointData[] = [
+        { id: 'ep1', integration_id: 'i1', channel_id: 'C123', channel_name: '#general', routing_mode: 'receptionist', direct_workspace_id: null },
+      ]
+      vi.mocked(entryPointRepo.findByIntegration).mockResolvedValue(eps)
+
+      const result = await useCase.listEntryPoints('i1')
+      expect(result).toEqual(eps)
+    })
+  })
+
+  describe('createEntryPoint', () => {
+    it('creates an entry point with receptionist mode by default', async () => {
+      const { integrationRepo, entryPointRepo, useCase } = setup()
+      vi.mocked(integrationRepo.findByOrgAndType).mockResolvedValue({ id: 'i1', org_id: 'org-1', type: 'slack', status: 'active' })
+
+      await useCase.createEntryPoint('org-1', 'slack', { channel_id: 'C123', channel_name: '#support' })
+
+      expect(entryPointRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          integration_id: 'i1',
+          channel_id: 'C123',
+          channel_name: '#support',
+          routing_mode: 'receptionist',
+          direct_workspace_id: null,
+        }),
+      )
+    })
+
+    it('creates an entry point with direct routing mode', async () => {
+      const { integrationRepo, entryPointRepo, useCase } = setup()
+      vi.mocked(integrationRepo.findByOrgAndType).mockResolvedValue({ id: 'i1', org_id: 'org-1', type: 'slack', status: 'active' })
+
+      await useCase.createEntryPoint('org-1', 'slack', {
+        channel_id: 'C456',
+        channel_name: '#billing',
+        routing_mode: 'direct',
+        direct_workspace_id: 'ws-billing',
+      })
+
+      expect(entryPointRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          routing_mode: 'direct',
+          direct_workspace_id: 'ws-billing',
+        }),
+      )
+    })
+
+    it('rejects if integration not found', async () => {
+      const { integrationRepo, useCase } = setup()
+      vi.mocked(integrationRepo.findByOrgAndType).mockResolvedValue(null)
+
+      await expect(useCase.createEntryPoint('org-1', 'slack', { channel_id: 'C123' })).rejects.toThrow()
+    })
+  })
+
+  describe('updateEntryPoint', () => {
+    it('updates routing mode', async () => {
+      const { entryPointRepo, useCase } = setup()
+      vi.mocked(entryPointRepo.findById).mockResolvedValue({
+        id: 'ep1', integration_id: 'i1', channel_id: 'C123', channel_name: '#general',
+        routing_mode: 'receptionist', direct_workspace_id: null,
+      })
+
+      await useCase.updateEntryPoint('ep1', { routing_mode: 'direct', direct_workspace_id: 'ws-1' })
+
+      expect(entryPointRepo.update).toHaveBeenCalledWith('ep1', { routing_mode: 'direct', direct_workspace_id: 'ws-1' })
+    })
+
+    it('rejects if entry point not found', async () => {
+      const { entryPointRepo, useCase } = setup()
+      vi.mocked(entryPointRepo.findById).mockResolvedValue(null)
+
+      await expect(useCase.updateEntryPoint('ep-999', { routing_mode: 'direct' })).rejects.toThrow()
+    })
+
+    it('clears direct_workspace_id when switching to receptionist', async () => {
+      const { entryPointRepo, useCase } = setup()
+      vi.mocked(entryPointRepo.findById).mockResolvedValue({
+        id: 'ep1', integration_id: 'i1', channel_id: 'C123', channel_name: '#general',
+        routing_mode: 'direct', direct_workspace_id: 'ws-1',
+      })
+
+      await useCase.updateEntryPoint('ep1', { routing_mode: 'receptionist' })
+
+      expect(entryPointRepo.update).toHaveBeenCalledWith('ep1', { routing_mode: 'receptionist', direct_workspace_id: null })
+    })
+  })
+
+  describe('deleteEntryPoint', () => {
+    it('deletes an entry point', async () => {
+      const { entryPointRepo, useCase } = setup()
+      vi.mocked(entryPointRepo.findById).mockResolvedValue({
+        id: 'ep1', integration_id: 'i1', channel_id: 'C123', channel_name: '#general',
+        routing_mode: 'receptionist', direct_workspace_id: null,
+      })
+
+      await useCase.deleteEntryPoint('ep1')
+
+      expect(entryPointRepo.delete).toHaveBeenCalledWith('ep1')
+    })
+
+    it('rejects if entry point not found', async () => {
+      const { entryPointRepo, useCase } = setup()
+      vi.mocked(entryPointRepo.findById).mockResolvedValue(null)
+
+      await expect(useCase.deleteEntryPoint('ep-999')).rejects.toThrow()
+    })
+  })
+
+  describe('resolveRouting', () => {
+    it('returns receptionist when no entry point exists', async () => {
+      const { entryPointRepo, useCase } = setup()
+      vi.mocked(entryPointRepo.findByChannel).mockResolvedValue(null)
+
+      const result = await useCase.resolveRouting('slack', 'C123')
+      expect(result).toEqual({ mode: 'receptionist' })
+    })
+
+    it('returns receptionist for entry points with receptionist mode', async () => {
+      const { entryPointRepo, useCase } = setup()
+      vi.mocked(entryPointRepo.findByChannel).mockResolvedValue({
+        id: 'ep1', integration_id: 'i1', channel_id: 'C123', channel_name: '#general',
+        routing_mode: 'receptionist', direct_workspace_id: null,
+        integration_type: 'slack', org_id: 'org-1',
+      })
+
+      const result = await useCase.resolveRouting('slack', 'C123')
+      expect(result).toEqual({ mode: 'receptionist', orgId: 'org-1' })
+    })
+
+    it('returns direct with workspace ID for direct entry points', async () => {
+      const { entryPointRepo, useCase } = setup()
+      vi.mocked(entryPointRepo.findByChannel).mockResolvedValue({
+        id: 'ep1', integration_id: 'i1', channel_id: 'C456', channel_name: '#billing',
+        routing_mode: 'direct', direct_workspace_id: 'ws-billing',
+        integration_type: 'slack', org_id: 'org-1',
+      })
+
+      const result = await useCase.resolveRouting('slack', 'C456')
+      expect(result).toEqual({ mode: 'direct', workspaceId: 'ws-billing', orgId: 'org-1' })
+    })
+  })
+})

--- a/src/application/integration/ManageEntryPointUseCase.ts
+++ b/src/application/integration/ManageEntryPointUseCase.ts
@@ -1,0 +1,79 @@
+import type { IntegrationRepository, EntryPointRepository, RoutingMode } from '../../domain/integration/repository.js'
+import { generateId } from '../../domain/shared/EntityId.js'
+import { NotFoundError } from '../../domain/shared/errors.js'
+
+interface CreateEntryPointInput {
+  channel_id: string
+  channel_name?: string
+  routing_mode?: RoutingMode
+  direct_workspace_id?: string
+}
+
+interface UpdateEntryPointInput {
+  channel_name?: string
+  routing_mode?: RoutingMode
+  direct_workspace_id?: string | null
+}
+
+interface RoutingResult {
+  mode: 'receptionist' | 'direct'
+  workspaceId?: string
+  orgId?: string
+}
+
+export class ManageEntryPointUseCase {
+  constructor(
+    private readonly integrationRepo: IntegrationRepository,
+    private readonly entryPointRepo: EntryPointRepository,
+  ) {}
+
+  async listEntryPoints(integrationId: string) {
+    return this.entryPointRepo.findByIntegration(integrationId)
+  }
+
+  async createEntryPoint(orgId: string, type: string, input: CreateEntryPointInput): Promise<void> {
+    const integration = await this.integrationRepo.findByOrgAndType(orgId, type)
+    if (!integration) throw new NotFoundError('Integration', type)
+
+    await this.entryPointRepo.create({
+      id: generateId(),
+      integration_id: integration.id,
+      channel_id: input.channel_id,
+      channel_name: input.channel_name || null,
+      routing_mode: input.routing_mode || 'receptionist',
+      direct_workspace_id: input.routing_mode === 'direct' ? (input.direct_workspace_id || null) : null,
+    })
+  }
+
+  async updateEntryPoint(id: string, input: UpdateEntryPointInput): Promise<void> {
+    const ep = await this.entryPointRepo.findById(id)
+    if (!ep) throw new NotFoundError('EntryPoint', id)
+
+    const update: UpdateEntryPointInput = { ...input }
+
+    // Clear direct_workspace_id when switching to receptionist
+    if (input.routing_mode === 'receptionist') {
+      update.direct_workspace_id = null
+    }
+
+    await this.entryPointRepo.update(id, update)
+  }
+
+  async deleteEntryPoint(id: string): Promise<void> {
+    const ep = await this.entryPointRepo.findById(id)
+    if (!ep) throw new NotFoundError('EntryPoint', id)
+    await this.entryPointRepo.delete(id)
+  }
+
+  async resolveRouting(type: string, channelId: string): Promise<RoutingResult> {
+    const ep = await this.entryPointRepo.findByChannel(type, channelId)
+
+    if (!ep) return { mode: 'receptionist' }
+
+    if (ep.routing_mode === 'direct' && ep.direct_workspace_id) {
+      return { mode: 'direct', workspaceId: ep.direct_workspace_id, orgId: ep.org_id }
+    }
+
+    return { mode: 'receptionist', orgId: ep.org_id }
+  }
+}

--- a/src/application/integration/ManageIntegrationUseCase.test.ts
+++ b/src/application/integration/ManageIntegrationUseCase.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ManageIntegrationUseCase } from './ManageIntegrationUseCase.js'
+import { mockIntegrationRepo } from '../../__tests__/mocks.js'
+import type { IntegrationData } from '../../domain/integration/repository.js'
+
+describe('ManageIntegrationUseCase', () => {
+  function setup() {
+    const integrationRepo = mockIntegrationRepo()
+    const useCase = new ManageIntegrationUseCase(integrationRepo)
+    return { integrationRepo, useCase }
+  }
+
+  describe('listIntegrations', () => {
+    it('returns all integrations for the org', async () => {
+      const { integrationRepo, useCase } = setup()
+      const integrations: IntegrationData[] = [
+        { id: 'i1', org_id: 'org-1', type: 'slack', status: 'active' },
+        { id: 'i2', org_id: 'org-1', type: 'whatsapp', status: 'active' },
+      ]
+      vi.mocked(integrationRepo.findByOrg).mockResolvedValue(integrations)
+
+      const result = await useCase.listIntegrations('org-1')
+      expect(result).toEqual(integrations)
+    })
+  })
+
+  describe('activate', () => {
+    it('creates an integration if none exists', async () => {
+      const { integrationRepo, useCase } = setup()
+      vi.mocked(integrationRepo.findByOrgAndType).mockResolvedValue(null)
+
+      await useCase.activate('org-1', 'slack')
+
+      expect(integrationRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ org_id: 'org-1', type: 'slack', status: 'active' }),
+      )
+    })
+
+    it('reactivates an inactive integration', async () => {
+      const { integrationRepo, useCase } = setup()
+      vi.mocked(integrationRepo.findByOrgAndType).mockResolvedValue(
+        { id: 'i1', org_id: 'org-1', type: 'slack', status: 'inactive' },
+      )
+
+      await useCase.activate('org-1', 'slack')
+
+      expect(integrationRepo.updateStatus).toHaveBeenCalledWith('i1', 'active')
+    })
+
+    it('does nothing if already active', async () => {
+      const { integrationRepo, useCase } = setup()
+      vi.mocked(integrationRepo.findByOrgAndType).mockResolvedValue(
+        { id: 'i1', org_id: 'org-1', type: 'slack', status: 'active' },
+      )
+
+      await useCase.activate('org-1', 'slack')
+
+      expect(integrationRepo.create).not.toHaveBeenCalled()
+      expect(integrationRepo.updateStatus).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('deactivate', () => {
+    it('sets integration to inactive', async () => {
+      const { integrationRepo, useCase } = setup()
+      vi.mocked(integrationRepo.findByOrgAndType).mockResolvedValue(
+        { id: 'i1', org_id: 'org-1', type: 'slack', status: 'active' },
+      )
+
+      await useCase.deactivate('org-1', 'slack')
+
+      expect(integrationRepo.updateStatus).toHaveBeenCalledWith('i1', 'inactive')
+    })
+
+    it('does nothing if not found', async () => {
+      const { integrationRepo, useCase } = setup()
+      vi.mocked(integrationRepo.findByOrgAndType).mockResolvedValue(null)
+
+      await useCase.deactivate('org-1', 'slack')
+
+      expect(integrationRepo.updateStatus).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/application/integration/ManageIntegrationUseCase.ts
+++ b/src/application/integration/ManageIntegrationUseCase.ts
@@ -1,0 +1,33 @@
+import type { IntegrationRepository } from '../../domain/integration/repository.js'
+import { generateId } from '../../domain/shared/EntityId.js'
+
+export class ManageIntegrationUseCase {
+  constructor(private readonly integrationRepo: IntegrationRepository) {}
+
+  async listIntegrations(orgId: string) {
+    return this.integrationRepo.findByOrg(orgId)
+  }
+
+  async activate(orgId: string, type: string): Promise<void> {
+    const existing = await this.integrationRepo.findByOrgAndType(orgId, type)
+
+    if (existing && existing.status === 'active') return
+    if (existing && existing.status === 'inactive') {
+      await this.integrationRepo.updateStatus(existing.id, 'active')
+      return
+    }
+
+    await this.integrationRepo.create({
+      id: generateId(),
+      org_id: orgId,
+      type,
+      status: 'active',
+    })
+  }
+
+  async deactivate(orgId: string, type: string): Promise<void> {
+    const existing = await this.integrationRepo.findByOrgAndType(orgId, type)
+    if (!existing) return
+    await this.integrationRepo.updateStatus(existing.id, 'inactive')
+  }
+}

--- a/src/container.ts
+++ b/src/container.ts
@@ -20,6 +20,8 @@ import { MysqlPromptTemplateRepository } from './infrastructure/persistence/mysq
 import { MysqlGuardrailEventRepository } from './infrastructure/persistence/mysql/MysqlGuardrailEventRepository.js'
 import { MysqlGuardrailPolicyRepository } from './infrastructure/persistence/mysql/MysqlGuardrailPolicyRepository.js'
 import { MysqlInstalledGuardrailRepository } from './infrastructure/persistence/mysql/MysqlInstalledGuardrailRepository.js'
+import { MysqlIntegrationRepository } from './infrastructure/persistence/mysql/MysqlIntegrationRepository.js'
+import { MysqlEntryPointRepository } from './infrastructure/persistence/mysql/MysqlEntryPointRepository.js'
 import { DynamicPluginLoader } from './infrastructure/plugins/DynamicPluginLoader.js'
 import { PreQueryGuardDepsImpl } from './infrastructure/guard/PreQueryGuardDepsImpl.js'
 import { PreQueryGuardService } from './application/query/PreQueryGuardService.js'
@@ -93,6 +95,8 @@ import { GetSecurityOverviewUseCase } from './application/guardrail/GetSecurityO
 import { CreatePolicyOverrideUseCase } from './application/guardrail/CreatePolicyOverrideUseCase.js'
 import { InstallGuardrailUseCase } from './application/guardrail/InstallGuardrailUseCase.js'
 import { UninstallGuardrailUseCase } from './application/guardrail/UninstallGuardrailUseCase.js'
+import { ManageIntegrationUseCase } from './application/integration/ManageIntegrationUseCase.js'
+import { ManageEntryPointUseCase } from './application/integration/ManageEntryPointUseCase.js'
 
 // Presentation
 import { createRequireAuth } from './presentation/middleware/auth.js'
@@ -101,6 +105,7 @@ import { createOrgRoutes } from './presentation/routes/org.js'
 import { createWorkspaceRoutes } from './presentation/routes/workspaces.js'
 import { createConversationRoutes } from './presentation/routes/conversations.js'
 import { createConnectorRoutes } from './presentation/routes/connectors.js'
+import { createIntegrationRoutes } from './presentation/routes/integrations.js'
 import { createQueryRoutes } from './presentation/routes/query.js'
 import { createQueueRoutes } from './presentation/routes/queues.js'
 import { createRouteRoutes } from './presentation/routes/route.js'
@@ -154,6 +159,8 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
   const getConnectionsUseCase = new GetConnectionsUseCase(workspaceRepo)
   const getKnowledgeUseCase = new GetKnowledgeUseCase(workspaceRepo, conversationRepo)
   const guardrailPolicyRepo = new MysqlGuardrailPolicyRepository(pool)
+  const integrationRepo = new MysqlIntegrationRepository(pool)
+  const entryPointRepo = new MysqlEntryPointRepository(pool)
   const installedGuardrailRepo = new MysqlInstalledGuardrailRepository(pool)
   const pluginLoader = new DynamicPluginLoader()
   const guardrailEventRepoForCompliance = new MysqlGuardrailEventRepository(pool)
@@ -371,9 +378,12 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
   const guardrailPolicyRoutes = createGuardrailPolicyRoutes({ managePoliciesUseCase, getSecurityOverviewUseCase, createPolicyOverrideUseCase, listAvailableGuardrails, requireAuth })
 
   // Installed guardrails (marketplace)
+  const manageIntegrationUseCase = new ManageIntegrationUseCase(integrationRepo)
+  const manageEntryPointUseCase = new ManageEntryPointUseCase(integrationRepo, entryPointRepo)
   const installGuardrailUseCase = new InstallGuardrailUseCase(installedGuardrailRepo, pluginLoader, corePluginIds)
   const uninstallGuardrailUseCase = new UninstallGuardrailUseCase(installedGuardrailRepo, corePluginIds)
   const installedGuardrailRoutes = createInstalledGuardrailRoutes({ installGuardrailUseCase, uninstallGuardrailUseCase, installedGuardrailRepo, requireAuth })
+  const integrationRoutes = createIntegrationRoutes({ manageIntegrationUseCase, manageEntryPointUseCase, integrationRepo, entryPointRepo, requireAuth })
 
   const container = {
     // Infrastructure
@@ -394,8 +404,9 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
     executeQueryUseCase, routeMessageUseCase, manageQueuesUseCase, savePromptUseCase,
     managePoliciesUseCase, getSecurityOverviewUseCase, createPolicyOverrideUseCase,
     installGuardrailUseCase, uninstallGuardrailUseCase,
+    manageIntegrationUseCase, manageEntryPointUseCase, integrationRepo, entryPointRepo,
     // Routes
-    authRoutes, orgRoutes, workspaceRoutes, conversationRoutes, connectorRoutes, queryRoutes, queueRoutes, routeRoutes, promptRoutes, guardrailPolicyRoutes, installedGuardrailRoutes,
+    authRoutes, orgRoutes, workspaceRoutes, conversationRoutes, connectorRoutes, queryRoutes, queueRoutes, routeRoutes, promptRoutes, guardrailPolicyRoutes, installedGuardrailRoutes, integrationRoutes,
   }
 
   return container

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -677,6 +677,90 @@ const migrations: Migration[] = [
       }
     },
   },
+  {
+    version: 24,
+    name: 'consumer integrations table',
+    up: async (pool) => {
+      await pool.execute(`
+        CREATE TABLE IF NOT EXISTS consumer_integrations (
+          id VARCHAR(64) PRIMARY KEY,
+          org_id VARCHAR(64) NOT NULL,
+          type VARCHAR(50) NOT NULL,
+          status ENUM('active', 'inactive') DEFAULT 'active',
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+          updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+          FOREIGN KEY (org_id) REFERENCES organisations(id) ON DELETE CASCADE,
+          UNIQUE KEY unique_type_per_org (org_id, type)
+        )
+      `);
+    },
+  },
+  {
+    version: 25,
+    name: 'entry points table',
+    up: async (pool) => {
+      await pool.execute(`
+        CREATE TABLE IF NOT EXISTS entry_points (
+          id VARCHAR(64) PRIMARY KEY,
+          integration_id VARCHAR(64) NOT NULL,
+          channel_id VARCHAR(255) NOT NULL,
+          channel_name VARCHAR(255),
+          routing_mode ENUM('receptionist', 'direct') DEFAULT 'receptionist',
+          direct_workspace_id VARCHAR(64),
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+          FOREIGN KEY (integration_id) REFERENCES consumer_integrations(id) ON DELETE CASCADE,
+          FOREIGN KEY (direct_workspace_id) REFERENCES workspaces(id) ON DELETE SET NULL,
+          UNIQUE KEY unique_channel (integration_id, channel_id)
+        )
+      `);
+    },
+  },
+  {
+    version: 26,
+    name: 'migrate consumers to integrations and entry points',
+    up: async (pool) => {
+      // For each distinct (org_id, type) in the consumers table, create a consumer_integration row.
+      // Then for each consumer with channels in config, create entry_point rows.
+      const [consumers] = await pool.execute<mysql.RowDataPacket[]>(
+        `SELECT c.id, c.workspace_id, c.type, c.config, c.status, w.org_id
+         FROM consumers c
+         JOIN workspaces w ON w.id = c.workspace_id
+         WHERE w.org_id IS NOT NULL`
+      );
+
+      const createdIntegrations = new Map<string, string>(); // key: org_id:type -> integration_id
+
+      for (const row of consumers) {
+        const key = `${row.org_id}:${row.type}`;
+        let integrationId = createdIntegrations.get(key);
+
+        if (!integrationId) {
+          integrationId = generateId();
+          await pool.execute(
+            `INSERT IGNORE INTO consumer_integrations (id, org_id, type, status) VALUES (?, ?, ?, 'active')`,
+            [integrationId, row.org_id, row.type]
+          );
+          createdIntegrations.set(key, integrationId);
+        }
+
+        // Parse channels from config JSON
+        let channels: string[] = [];
+        try {
+          const cfg = typeof row.config === 'string' ? JSON.parse(row.config) : row.config;
+          channels = cfg?.channels || [];
+        } catch { /* skip invalid JSON */ }
+
+        for (const channelId of channels) {
+          if (!channelId) continue;
+          const epId = generateId();
+          await pool.execute(
+            `INSERT IGNORE INTO entry_points (id, integration_id, channel_id, routing_mode) VALUES (?, ?, ?, 'receptionist')`,
+            [epId, integrationId, channelId]
+          );
+        }
+      }
+    },
+  },
 ];
 
 interface SchemaMigrationRow extends mysql.RowDataPacket {

--- a/src/domain/integration/repository.ts
+++ b/src/domain/integration/repository.ts
@@ -1,0 +1,43 @@
+export type RoutingMode = 'receptionist' | 'direct'
+
+export interface IntegrationData {
+  id: string
+  org_id: string
+  type: string
+  status: 'active' | 'inactive'
+  created_at?: string
+  updated_at?: string
+}
+
+export interface EntryPointData {
+  id: string
+  integration_id: string
+  channel_id: string
+  channel_name: string | null
+  routing_mode: RoutingMode
+  direct_workspace_id: string | null
+  created_at?: string
+}
+
+export interface EntryPointWithIntegration extends EntryPointData {
+  integration_type: string
+  org_id: string
+}
+
+export interface IntegrationRepository {
+  findByOrg(orgId: string): Promise<IntegrationData[]>
+  findByOrgAndType(orgId: string, type: string): Promise<IntegrationData | null>
+  create(data: IntegrationData): Promise<void>
+  updateStatus(id: string, status: 'active' | 'inactive'): Promise<void>
+  delete(id: string): Promise<void>
+}
+
+export interface EntryPointRepository {
+  findByIntegration(integrationId: string): Promise<EntryPointData[]>
+  findByChannel(type: string, channelId: string): Promise<EntryPointWithIntegration | null>
+  findById(id: string): Promise<EntryPointData | null>
+  create(data: EntryPointData): Promise<void>
+  update(id: string, data: { channel_name?: string; routing_mode?: RoutingMode; direct_workspace_id?: string | null }): Promise<void>
+  delete(id: string): Promise<void>
+  findByOrg(orgId: string): Promise<Array<EntryPointData & { integration_type: string }>>
+}

--- a/src/infrastructure/persistence/mysql/MysqlEntryPointRepository.ts
+++ b/src/infrastructure/persistence/mysql/MysqlEntryPointRepository.ts
@@ -1,0 +1,98 @@
+import type mysql from 'mysql2/promise'
+import type { EntryPointRepository, EntryPointData, EntryPointWithIntegration, RoutingMode } from '../../../domain/integration/repository.js'
+
+interface EntryPointRow extends mysql.RowDataPacket {
+  id: string
+  integration_id: string
+  channel_id: string
+  channel_name: string | null
+  routing_mode: string
+  direct_workspace_id: string | null
+  created_at: string
+}
+
+interface EntryPointWithTypeRow extends EntryPointRow {
+  integration_type: string
+  org_id: string
+}
+
+export class MysqlEntryPointRepository implements EntryPointRepository {
+  constructor(private readonly pool: mysql.Pool) {}
+
+  async findByIntegration(integrationId: string): Promise<EntryPointData[]> {
+    const [rows] = await this.pool.execute<EntryPointRow[]>(
+      'SELECT * FROM entry_points WHERE integration_id = ? ORDER BY channel_name, channel_id',
+      [integrationId],
+    )
+    return rows.map(mapRow)
+  }
+
+  async findByChannel(type: string, channelId: string): Promise<EntryPointWithIntegration | null> {
+    const [rows] = await this.pool.execute<EntryPointWithTypeRow[]>(
+      `SELECT ep.*, ci.type AS integration_type, ci.org_id
+       FROM entry_points ep
+       JOIN consumer_integrations ci ON ci.id = ep.integration_id
+       WHERE ci.type = ? AND ep.channel_id = ? AND ci.status = 'active'
+       LIMIT 1`,
+      [type, channelId],
+    )
+    if (!rows[0]) return null
+    const r = rows[0]
+    return { ...mapRow(r), integration_type: r.integration_type, org_id: r.org_id }
+  }
+
+  async findById(id: string): Promise<EntryPointData | null> {
+    const [rows] = await this.pool.execute<EntryPointRow[]>(
+      'SELECT * FROM entry_points WHERE id = ? LIMIT 1', [id],
+    )
+    return rows[0] ? mapRow(rows[0]) : null
+  }
+
+  async create(data: EntryPointData): Promise<void> {
+    await this.pool.execute(
+      'INSERT INTO entry_points (id, integration_id, channel_id, channel_name, routing_mode, direct_workspace_id) VALUES (?, ?, ?, ?, ?, ?)',
+      [data.id, data.integration_id, data.channel_id, data.channel_name, data.routing_mode, data.direct_workspace_id],
+    )
+  }
+
+  async update(id: string, data: { channel_name?: string; routing_mode?: RoutingMode; direct_workspace_id?: string | null }): Promise<void> {
+    const sets: string[] = []
+    const params: (string | null)[] = []
+
+    if (data.channel_name !== undefined) { sets.push('channel_name = ?'); params.push(data.channel_name); }
+    if (data.routing_mode !== undefined) { sets.push('routing_mode = ?'); params.push(data.routing_mode); }
+    if (data.direct_workspace_id !== undefined) { sets.push('direct_workspace_id = ?'); params.push(data.direct_workspace_id); }
+
+    if (sets.length === 0) return
+    params.push(id)
+    await this.pool.execute(`UPDATE entry_points SET ${sets.join(', ')} WHERE id = ?`, params)
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.pool.execute('DELETE FROM entry_points WHERE id = ?', [id])
+  }
+
+  async findByOrg(orgId: string): Promise<Array<EntryPointData & { integration_type: string }>> {
+    const [rows] = await this.pool.execute<EntryPointWithTypeRow[]>(
+      `SELECT ep.*, ci.type AS integration_type, ci.org_id
+       FROM entry_points ep
+       JOIN consumer_integrations ci ON ci.id = ep.integration_id
+       WHERE ci.org_id = ?
+       ORDER BY ci.type, ep.channel_name, ep.channel_id`,
+      [orgId],
+    )
+    return rows.map(r => ({ ...mapRow(r), integration_type: r.integration_type }))
+  }
+}
+
+function mapRow(r: EntryPointRow): EntryPointData {
+  return {
+    id: r.id,
+    integration_id: r.integration_id,
+    channel_id: r.channel_id,
+    channel_name: r.channel_name,
+    routing_mode: r.routing_mode as RoutingMode,
+    direct_workspace_id: r.direct_workspace_id,
+    created_at: r.created_at,
+  }
+}

--- a/src/infrastructure/persistence/mysql/MysqlIntegrationRepository.ts
+++ b/src/infrastructure/persistence/mysql/MysqlIntegrationRepository.ts
@@ -1,0 +1,50 @@
+import type mysql from 'mysql2/promise'
+import type { IntegrationRepository, IntegrationData } from '../../../domain/integration/repository.js'
+
+interface IntegrationRow extends mysql.RowDataPacket {
+  id: string
+  org_id: string
+  type: string
+  status: string
+  created_at: string
+  updated_at: string
+}
+
+export class MysqlIntegrationRepository implements IntegrationRepository {
+  constructor(private readonly pool: mysql.Pool) {}
+
+  async findByOrg(orgId: string): Promise<IntegrationData[]> {
+    const [rows] = await this.pool.execute<IntegrationRow[]>(
+      'SELECT * FROM consumer_integrations WHERE org_id = ? ORDER BY type',
+      [orgId],
+    )
+    return rows.map(mapRow)
+  }
+
+  async findByOrgAndType(orgId: string, type: string): Promise<IntegrationData | null> {
+    const [rows] = await this.pool.execute<IntegrationRow[]>(
+      'SELECT * FROM consumer_integrations WHERE org_id = ? AND type = ? LIMIT 1',
+      [orgId, type],
+    )
+    return rows[0] ? mapRow(rows[0]) : null
+  }
+
+  async create(data: IntegrationData): Promise<void> {
+    await this.pool.execute(
+      'INSERT INTO consumer_integrations (id, org_id, type, status) VALUES (?, ?, ?, ?)',
+      [data.id, data.org_id, data.type, data.status],
+    )
+  }
+
+  async updateStatus(id: string, status: 'active' | 'inactive'): Promise<void> {
+    await this.pool.execute('UPDATE consumer_integrations SET status = ? WHERE id = ?', [status, id])
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.pool.execute('DELETE FROM consumer_integrations WHERE id = ?', [id])
+  }
+}
+
+function mapRow(r: IntegrationRow): IntegrationData {
+  return { id: r.id, org_id: r.org_id, type: r.type, status: r.status as IntegrationData['status'], created_at: r.created_at, updated_at: r.updated_at }
+}

--- a/src/presentation/routes/integrations.ts
+++ b/src/presentation/routes/integrations.ts
@@ -1,0 +1,115 @@
+import { Hono } from 'hono'
+import { z } from 'zod'
+import type { ManageIntegrationUseCase } from '../../application/integration/ManageIntegrationUseCase.js'
+import type { ManageEntryPointUseCase } from '../../application/integration/ManageEntryPointUseCase.js'
+import type { IntegrationRepository } from '../../domain/integration/repository.js'
+import type { EntryPointRepository } from '../../domain/integration/repository.js'
+import { parseBody } from '../middleware/validate.js'
+import type { AuthUser, AuthEnv } from '../middleware/auth.js'
+import { NotFoundError, ValidationError } from '../../domain/shared/errors.js'
+
+const createEntryPointSchema = z.object({
+  type: z.string().min(1).max(50),
+  channel_id: z.string().min(1).max(255),
+  channel_name: z.string().max(255).optional(),
+  routing_mode: z.enum(['receptionist', 'direct']).optional(),
+  direct_workspace_id: z.string().max(64).optional(),
+})
+
+const updateEntryPointSchema = z.object({
+  channel_name: z.string().max(255).optional(),
+  routing_mode: z.enum(['receptionist', 'direct']).optional(),
+  direct_workspace_id: z.string().max(64).nullable().optional(),
+})
+
+interface IntegrationRouteDeps {
+  manageIntegrationUseCase: ManageIntegrationUseCase
+  manageEntryPointUseCase: ManageEntryPointUseCase
+  integrationRepo: IntegrationRepository
+  entryPointRepo: EntryPointRepository
+  requireAuth: (c: import('hono').Context, next: import('hono').Next) => Promise<Response | void>
+}
+
+export function createIntegrationRoutes(deps: IntegrationRouteDeps) {
+  const routes = new Hono<AuthEnv>()
+
+  routes.use('/api/integrations/*', deps.requireAuth)
+  routes.use('/api/integrations', deps.requireAuth)
+  routes.use('/api/entry-points/*', deps.requireAuth)
+  routes.use('/api/entry-points', deps.requireAuth)
+
+  // GET /api/integrations - list active integrations for the org
+  routes.get('/api/integrations', async (c) => {
+    const user = c.get('user') as AuthUser
+    const integrations = await deps.manageIntegrationUseCase.listIntegrations(user.org_id)
+    return c.json({ integrations })
+  })
+
+  // POST /api/integrations/:type/activate - activate a consumer type
+  routes.post('/api/integrations/:type/activate', async (c) => {
+    const user = c.get('user') as AuthUser
+    await deps.manageIntegrationUseCase.activate(user.org_id, c.req.param('type'))
+    return c.json({ status: 'ok' })
+  })
+
+  // POST /api/integrations/:type/deactivate - deactivate a consumer type
+  routes.post('/api/integrations/:type/deactivate', async (c) => {
+    const user = c.get('user') as AuthUser
+    await deps.manageIntegrationUseCase.deactivate(user.org_id, c.req.param('type'))
+    return c.json({ status: 'ok' })
+  })
+
+  // GET /api/entry-points - list all entry points for the org
+  routes.get('/api/entry-points', async (c) => {
+    const user = c.get('user') as AuthUser
+    const entryPoints = await deps.entryPointRepo.findByOrg(user.org_id)
+    return c.json({ entryPoints })
+  })
+
+  // POST /api/entry-points - create a new entry point
+  routes.post('/api/entry-points', async (c) => {
+    const user = c.get('user') as AuthUser
+    const body = await parseBody(c, createEntryPointSchema)
+    if (!body.success) return body.response
+
+    try {
+      await deps.manageEntryPointUseCase.createEntryPoint(user.org_id, body.data.type, {
+        channel_id: body.data.channel_id,
+        channel_name: body.data.channel_name,
+        routing_mode: body.data.routing_mode,
+        direct_workspace_id: body.data.direct_workspace_id,
+      })
+      return c.json({ status: 'ok' })
+    } catch (err) {
+      if (err instanceof NotFoundError) return c.json({ error: 'integration_not_found' }, 404)
+      throw err
+    }
+  })
+
+  // PUT /api/entry-points/:id - update an entry point
+  routes.put('/api/entry-points/:id', async (c) => {
+    const body = await parseBody(c, updateEntryPointSchema)
+    if (!body.success) return body.response
+
+    try {
+      await deps.manageEntryPointUseCase.updateEntryPoint(c.req.param('id'), body.data)
+      return c.json({ status: 'ok' })
+    } catch (err) {
+      if (err instanceof NotFoundError) return c.json({ error: 'not_found' }, 404)
+      throw err
+    }
+  })
+
+  // DELETE /api/entry-points/:id - delete an entry point
+  routes.delete('/api/entry-points/:id', async (c) => {
+    try {
+      await deps.manageEntryPointUseCase.deleteEntryPoint(c.req.param('id'))
+      return c.json({ status: 'ok' })
+    } catch (err) {
+      if (err instanceof NotFoundError) return c.json({ error: 'not_found' }, 404)
+      throw err
+    }
+  })
+
+  return routes
+}

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -14,13 +14,12 @@ const log = pino({ name: 'startup' })
  * Auto-start all registered consumers that have org-level credentials configured.
  * Iterates the plugin registry. No consumer-specific logic here.
  *
- * Message routing strategy:
- * 1. Try channel binding (channel_id → workspace_id lookup)
- * 2. If no binding found, fall back to the routing layer (receptionist pattern)
- * 3. If no routing layer (no org), use channel as workspace ID (legacy fallback)
+ * Message routing strategy (via entry_points table):
+ * 1. Look up entry_point for the incoming channel
+ * 2. If routing_mode = 'direct', execute against the bound workspace
+ * 3. Otherwise (receptionist mode or no entry_point), route through the receptionist
  */
 export async function startConsumers(container: Container): Promise<void> {
-  // Resolve org_id once for routing (single-tenant)
   const orgId = await container.orgRepo.getFirstOrgId()
 
   for (const plugin of container.consumerRegistry.list()) {
@@ -47,21 +46,19 @@ export async function startConsumers(container: Container): Promise<void> {
         continue
       }
 
-      const getWorkspace = async (channelId: string): Promise<Workspace | null> => {
-        const consumers = await container.workspaceRepo.findConsumersByType(plugin.type)
-        for (const row of consumers) {
-          const cfg = typeof row.config === 'string' ? JSON.parse(row.config) : row.config
-          if ((cfg.channels || []).includes(channelId)) return { id: row.workspace_id, name: '' }
-        }
-        return null
+      // Auto-activate integration record for this consumer type
+      if (orgId) {
+        await container.manageIntegrationUseCase.activate(orgId, plugin.type)
       }
 
       await plugin.start({
         onMessage: async (msg: IncomingMessage) => {
-          // 1. Try channel binding first
-          const ws = await getWorkspace(msg.channel)
-          if (ws) {
-            const result = await container.executeQueryUseCase.execute(ws.id, msg.query, {
+          // Resolve routing via entry_points
+          const routing = await container.manageEntryPointUseCase.resolveRouting(msg.consumerType, msg.channel)
+
+          if (routing.mode === 'direct' && routing.workspaceId) {
+            // Direct routing: bypass receptionist
+            const result = await container.executeQueryUseCase.execute(routing.workspaceId, msg.query, {
               consumerType: msg.consumerType,
               channel: msg.channel,
               userId: msg.userId,
@@ -71,10 +68,11 @@ export async function startConsumers(container: Container): Promise<void> {
             return { answer: result.answer, conversationId: result.conversationId || '' }
           }
 
-          // 2. No channel binding: use routing layer if available
-          if (orgId) {
+          // Receptionist routing (default)
+          const routingOrgId = routing.orgId || orgId
+          if (routingOrgId) {
             const result = await container.routeMessageUseCase.execute({
-              orgId,
+              orgId: routingOrgId,
               query: msg.query,
               consumerType: msg.consumerType,
               entryPoint: msg.channel,
@@ -84,19 +82,16 @@ export async function startConsumers(container: Container): Promise<void> {
             return { answer: result.answer, conversationId: result.conversationId }
           }
 
-          // 3. Legacy fallback: use channel as workspace ID
-          const result = await container.executeQueryUseCase.execute(msg.channel, msg.query, {
-            consumerType: msg.consumerType,
-            channel: msg.channel,
-            userId: msg.userId,
-            userName: msg.userName,
-            sessionId: msg.threadId,
-          })
-          return { answer: result.answer, conversationId: result.conversationId || '' }
+          // No org: cannot route
+          return { answer: 'No organisation configured. Please complete setup.', conversationId: '' }
         },
         onError: (err: Error) => log.error({ type: plugin.type, error: err.message }, 'Consumer error'),
         logger: log,
-        getWorkspaceForChannel: getWorkspace,
+        getWorkspaceForChannel: async (_channelId: string): Promise<Workspace | null> => {
+          // Legacy callback required by the consumer plugin interface.
+          // With the new entry_points model, routing is handled in onMessage.
+          return null
+        },
       }, credentials)
 
       if (plugin.sendMessage) {


### PR DESCRIPTION
## Summary

Moves consumers from workspace-level to organisation-level. Adds entry points with receptionist/direct routing modes.

- New domain: IntegrationRepository, EntryPointRepository, RoutingMode
- New use cases: ManageIntegrationUseCase, ManageEntryPointUseCase (18 TDD tests)
- New infra: MySQL repos, migrations 24-26 (tables + data migration)
- New routes: /api/integrations, /api/entry-points
- Startup refactor: resolveRouting instead of channel binding
- 356 tests pass

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)