### PR TITLE
feat: workspace-level provider selection and single-tenant signup guard

### DIFF
--- a/src/__tests__/mocks.ts
+++ b/src/__tests__/mocks.ts
@@ -16,6 +16,7 @@ import type { PromptTemplateRepository } from '../domain/prompt/repository.js'
 import type { GuardrailEventRepository } from '../domain/guardrail/repository.js'
 import type { GuardrailPolicyRepository } from '../domain/guardrail/policyRepository.js'
 import type { InstalledGuardrailRepository } from '../domain/guardrail/installedGuardrailRepository.js'
+import type { TenantService } from '../application/ports/TenantService.js'
 
 // ── Stub data ──
 
@@ -30,7 +31,8 @@ export function stubUser(overrides: Partial<UserData> = {}): UserData {
 export function stubWorkspace(overrides: Partial<WorkspaceData> = {}): WorkspaceData {
   return {
     id: 'ws-test', org_id: 'org-1', team_id: 'team-1', name: 'Test Workspace',
-    status: 'active', model: 'claude-sonnet-4-20250514', system_prompt: 'You are helpful.',
+    status: 'active', model: 'claude-sonnet-4-20250514', provider_type: null,
+    system_prompt: 'You are helpful.',
     max_tool_rounds: 10, max_thread_history: 50, cold_timeout_minutes: 30,
     close_timeout_minutes: 60, is_default: false, created_by: 'user-1', created_at: '2024-01-01',
     updated_at: '2024-01-01',
@@ -72,6 +74,7 @@ export function stubConsumer(overrides: Partial<ConsumerData> = {}): ConsumerDat
 export function mockOrgRepo(): OrganisationRepository {
   return {
     findById: vi.fn().mockResolvedValue(null),
+    anyExists: vi.fn().mockResolvedValue(false),
     create: vi.fn().mockResolvedValue(undefined),
     updateName: vi.fn().mockResolvedValue(undefined),
     findUserByEmail: vi.fn().mockResolvedValue(null),
@@ -162,6 +165,7 @@ export function mockConversationRepo(): ConversationRepository {
     getAggregateData: vi.fn().mockResolvedValue({ total_tokens_input: 0, total_tokens_output: 0, total_cost_usd: 0, total_duration_ms: 0, query_count: 0 }),
     getTimestamps: vi.fn().mockResolvedValue(null),
     getWorkspaceModel: vi.fn().mockResolvedValue(null),
+    getWorkspaceProviderInfo: vi.fn().mockResolvedValue(null),
     findColdTransitionCandidates: vi.fn().mockResolvedValue([]),
     batchTransitionToCold: vi.fn().mockResolvedValue(undefined),
     findCloseTransitionCandidates: vi.fn().mockResolvedValue([]),
@@ -182,6 +186,16 @@ export function mockConversationRepo(): ConversationRepository {
 
 export function mockAuditRepo(): AuditLogRepository {
   return { create: vi.fn().mockResolvedValue(undefined) }
+}
+
+export function mockTenantService(overrides: Partial<TenantService> = {}): TenantService {
+  return {
+    allowMultipleOrgs: false,
+    scopeWorkspaceList: () => null,
+    verifyWorkspaceAccess: () => {},
+    resolveOrgForCreation: (orgId) => orgId,
+    ...overrides,
+  }
 }
 
 export function mockPasswordService(): PasswordService {

--- a/src/application/auth/SignupUseCase.test.ts
+++ b/src/application/auth/SignupUseCase.test.ts
@@ -1,16 +1,17 @@
 import { describe, it, expect, vi } from 'vitest'
-import { mockOrgRepo, mockWorkspaceRepo, mockPasswordService, mockTokenService } from '../../__tests__/mocks.js'
+import { mockOrgRepo, mockWorkspaceRepo, mockPasswordService, mockTokenService, mockTenantService } from '../../__tests__/mocks.js'
 import { SignupUseCase } from './SignupUseCase.js'
 import { ConflictError } from '../../domain/shared/errors.js'
 
 describe('SignupUseCase', () => {
-  function setup() {
+  function setup(allowMultipleOrgs = false) {
     const orgRepo = mockOrgRepo()
     const workspaceRepo = mockWorkspaceRepo()
     const passwordService = mockPasswordService()
     const tokenService = mockTokenService()
-    const useCase = new SignupUseCase(orgRepo, workspaceRepo, passwordService, tokenService)
-    return { orgRepo, workspaceRepo, passwordService, tokenService, useCase }
+    const tenantService = mockTenantService({ allowMultipleOrgs })
+    const useCase = new SignupUseCase(orgRepo, workspaceRepo, passwordService, tokenService, tenantService)
+    return { orgRepo, workspaceRepo, passwordService, tokenService, tenantService, useCase }
   }
 
   const validInput = {
@@ -53,5 +54,23 @@ describe('SignupUseCase', () => {
 
     await expect(useCase.execute(validInput)).rejects.toThrow(ConflictError)
     expect(orgRepo.create).not.toHaveBeenCalled()
+  })
+
+  it('rejects signup in single-tenant mode when an org already exists', async () => {
+    const { orgRepo, useCase } = setup(false)
+    vi.mocked(orgRepo.anyExists).mockResolvedValue(true)
+
+    await expect(useCase.execute(validInput)).rejects.toThrow(ConflictError)
+    expect(orgRepo.create).not.toHaveBeenCalled()
+  })
+
+  it('allows signup in multi-tenant mode when an org already exists', async () => {
+    const { orgRepo, useCase } = setup(true)
+    vi.mocked(orgRepo.anyExists).mockResolvedValue(true)
+    vi.mocked(orgRepo.userExistsByEmail).mockResolvedValue(false)
+
+    const result = await useCase.execute(validInput)
+
+    expect(result).toHaveProperty('orgId')
   })
 })

--- a/src/application/auth/SignupUseCase.ts
+++ b/src/application/auth/SignupUseCase.ts
@@ -2,6 +2,7 @@ import type { OrganisationRepository } from '../../domain/organisation/repositor
 import type { WorkspaceRepository } from '../../domain/workspace/repository.js'
 import type { PasswordService } from '../ports/PasswordService.js'
 import type { TokenService } from '../ports/TokenService.js'
+import type { TenantService } from '../ports/TenantService.js'
 import { generateId, generateSlug, generateWorkspaceId } from '../../domain/shared/EntityId.js'
 import { ConflictError } from '../../domain/shared/errors.js'
 import { DEFAULT_WORKSPACE_NAME, DEFAULT_RECEPTIONIST_PROMPT } from '../../defaults.js'
@@ -26,9 +27,17 @@ export class SignupUseCase {
     private readonly workspaceRepo: WorkspaceRepository,
     private readonly passwordService: PasswordService,
     private readonly tokenService: TokenService,
+    private readonly tenantService: TenantService,
   ) {}
 
   async execute(input: SignupInput): Promise<SignupOutput> {
+    if (!this.tenantService.allowMultipleOrgs) {
+      const orgExists = await this.orgRepo.anyExists()
+      if (orgExists) {
+        throw new ConflictError('An organisation already exists. Sign in instead.')
+      }
+    }
+
     const emailExists = await this.orgRepo.userExistsByEmail(input.adminEmail)
     if (emailExists) {
       throw new ConflictError('An account with this email already exists. Sign in instead.')

--- a/src/application/conversation/LifecycleUseCase.test.ts
+++ b/src/application/conversation/LifecycleUseCase.test.ts
@@ -28,6 +28,14 @@ function mockProviderRegistry(plugin?: ProviderPlugin): typeof ProviderRegistryT
   return { get: vi.fn().mockReturnValue(p) } as unknown as typeof ProviderRegistryType
 }
 
+function mockSettingValues(store: Record<string, string>) {
+  return async (keys: string[]) => {
+    const result: Record<string, string> = {}
+    for (const k of keys) result[k] = store[k] || ''
+    return result
+  }
+}
+
 describe('LifecycleUseCase', () => {
   let conversationRepo: ReturnType<typeof mockConversationRepo>
   let orgRepo: ReturnType<typeof mockOrgRepo>
@@ -107,11 +115,11 @@ describe('LifecycleUseCase', () => {
         { role: 'user', content: 'I need help' },
         { role: 'assistant', content: 'Sure, what do you need?' },
       ])
-      vi.mocked(orgRepo.getSettingValues).mockResolvedValue({
-        ai_api_key: 'sk-test',
+      vi.mocked(orgRepo.getSettingValues).mockImplementation(mockSettingValues({
         ai_provider_type: 'anthropic',
-      })
-      vi.mocked(conversationRepo.getWorkspaceModel).mockResolvedValue('claude-sonnet-4-20250514')
+        anthropic_api_key: 'sk-test',
+      }))
+      vi.mocked(conversationRepo.getWorkspaceProviderInfo).mockResolvedValue({ model: 'claude-sonnet-4-20250514', provider_type: null })
       vi.mocked(providerPlugin.createSimpleMessage).mockResolvedValue('Still need help?')
 
       await useCase.sendColdMessage(target)
@@ -140,10 +148,10 @@ describe('LifecycleUseCase', () => {
       vi.mocked(conversationRepo.findMessages).mockResolvedValue([
         { role: 'user', content: 'hello' },
       ])
-      vi.mocked(orgRepo.getSettingValues).mockResolvedValue({
-        ai_api_key: '',
+      vi.mocked(orgRepo.getSettingValues).mockImplementation(mockSettingValues({
         ai_provider_type: 'anthropic',
-      })
+      }))
+      vi.mocked(conversationRepo.getWorkspaceProviderInfo).mockResolvedValue({ model: 'claude-sonnet-4-20250514', provider_type: null })
 
       await useCase.sendColdMessage(target)
 
@@ -157,11 +165,7 @@ describe('LifecycleUseCase', () => {
       vi.mocked(conversationRepo.findMessages).mockResolvedValue([
         { role: 'user', content: 'hello' },
       ])
-      vi.mocked(orgRepo.getSettingValues).mockResolvedValue({
-        ai_api_key: 'sk-test',
-        ai_provider_type: 'anthropic',
-      })
-      vi.mocked(conversationRepo.getWorkspaceModel).mockResolvedValue(null)
+      vi.mocked(conversationRepo.getWorkspaceProviderInfo).mockResolvedValue(null)
 
       await useCase.sendColdMessage(target)
 
@@ -175,14 +179,11 @@ describe('LifecycleUseCase', () => {
       vi.mocked(conversationRepo.findMessages).mockResolvedValue([
         { role: 'user', content: 'hello' },
       ])
-      vi.mocked(orgRepo.getSettingValues).mockResolvedValue({
-        ai_api_key: 'sk-test',
-        ai_provider_type: '',
-      })
+      vi.mocked(orgRepo.getSettingValues).mockImplementation(mockSettingValues({}))
+      vi.mocked(conversationRepo.getWorkspaceProviderInfo).mockResolvedValue({ model: 'claude-sonnet-4-20250514', provider_type: null })
 
       await useCase.sendColdMessage(target)
 
-      // generateColdMessage catches the thrown error and returns ''
       expect(posterRegistry.post).toHaveBeenCalledWith(
         target,
         expect.stringContaining('checking in'),
@@ -194,10 +195,11 @@ describe('LifecycleUseCase', () => {
 
   describe('generateStats', () => {
     beforeEach(() => {
-      vi.mocked(orgRepo.getSettingValues).mockResolvedValue({
-        ai_api_key: 'sk-test',
+      vi.mocked(orgRepo.getSettingValues).mockImplementation(mockSettingValues({
         ai_provider_type: 'anthropic',
-      })
+        anthropic_api_key: 'sk-test',
+      }))
+      vi.mocked(conversationRepo.getWorkspaceProviderInfo).mockResolvedValue({ model: 'claude-sonnet-4-20250514', provider_type: null })
     })
 
     it('creates stats and completes with AI analysis', async () => {
@@ -215,7 +217,7 @@ describe('LifecycleUseCase', () => {
         closed_at: '2024-01-01T10:05:00Z',
         message_count: 2,
       })
-      vi.mocked(conversationRepo.getWorkspaceModel).mockResolvedValue('claude-sonnet-4-20250514')
+      vi.mocked(conversationRepo.getWorkspaceProviderInfo).mockResolvedValue({ model: 'claude-sonnet-4-20250514', provider_type: null })
 
       const analysisJson = JSON.stringify({
         sentiment_score: 3,
@@ -278,7 +280,7 @@ describe('LifecycleUseCase', () => {
         closed_at: '2024-01-01T10:01:00Z',
         message_count: 1,
       })
-      vi.mocked(conversationRepo.getWorkspaceModel).mockResolvedValue('claude-sonnet-4-20250514')
+      vi.mocked(conversationRepo.getWorkspaceProviderInfo).mockResolvedValue({ model: 'claude-sonnet-4-20250514', provider_type: null })
       vi.mocked(providerPlugin.createSimpleMessage).mockResolvedValue(
         JSON.stringify({ sentiment_score: 4, resolution_status: 'resolved', category: 'query', compliance_violations: [], knowledge_gaps: [], fraud_indicators: [], tools_used: [], summary: 'Test' }),
       )
@@ -315,7 +317,7 @@ describe('LifecycleUseCase', () => {
         closed_at: '2024-01-01T10:01:00Z',
         message_count: 1,
       })
-      vi.mocked(conversationRepo.getWorkspaceModel).mockResolvedValue(null)
+      vi.mocked(conversationRepo.getWorkspaceProviderInfo).mockResolvedValue(null)
 
       await useCase.generateStats('conv-1')
 
@@ -334,11 +336,10 @@ describe('LifecycleUseCase', () => {
       vi.mocked(conversationRepo.getTimestamps).mockResolvedValue({
         first_message_at: null, closed_at: null, message_count: 1,
       })
-      vi.mocked(conversationRepo.getWorkspaceModel).mockResolvedValue('claude-sonnet-4-20250514')
-      vi.mocked(orgRepo.getSettingValues).mockResolvedValue({
-        ai_api_key: '',
+      vi.mocked(conversationRepo.getWorkspaceProviderInfo).mockResolvedValue({ model: 'claude-sonnet-4-20250514', provider_type: null })
+      vi.mocked(orgRepo.getSettingValues).mockImplementation(mockSettingValues({
         ai_provider_type: 'anthropic',
-      })
+      }))
 
       await useCase.generateStats('conv-1')
 
@@ -359,7 +360,7 @@ describe('LifecycleUseCase', () => {
         closed_at: '2024-01-01T10:01:00Z',
         message_count: 1,
       })
-      vi.mocked(conversationRepo.getWorkspaceModel).mockResolvedValue('claude-sonnet-4-20250514')
+      vi.mocked(conversationRepo.getWorkspaceProviderInfo).mockResolvedValue({ model: 'claude-sonnet-4-20250514', provider_type: null })
       vi.mocked(providerPlugin.createSimpleMessage).mockRejectedValue(new Error('AI failed'))
 
       await useCase.generateStats('conv-1')
@@ -381,7 +382,7 @@ describe('LifecycleUseCase', () => {
         closed_at: '2024-01-01T10:01:00Z',
         message_count: 1,
       })
-      vi.mocked(conversationRepo.getWorkspaceModel).mockResolvedValue('claude-sonnet-4-20250514')
+      vi.mocked(conversationRepo.getWorkspaceProviderInfo).mockResolvedValue({ model: 'claude-sonnet-4-20250514', provider_type: null })
 
       const wrappedJson = '```json\n' + JSON.stringify({
         sentiment_score: 5,

--- a/src/application/conversation/LifecycleUseCase.ts
+++ b/src/application/conversation/LifecycleUseCase.ts
@@ -69,21 +69,20 @@ export class LifecycleUseCase {
 
       const aggregate = await this.conversationRepo.getAggregateData(conversationId)
       const timestamps = await this.conversationRepo.getTimestamps(conversationId)
-      const model = await this.conversationRepo.getWorkspaceModel(conversationId)
+      const providerInfo = await this.conversationRepo.getWorkspaceProviderInfo(conversationId)
 
-      if (!model) {
+      if (!providerInfo) {
         await this.conversationRepo.updateStatsStatus(statsId, 'failed')
         return
       }
 
-      const orgSettings = await this.orgRepo.getSettingValues(['ai_api_key', 'ai_provider_type'])
-      const apiKey = orgSettings['ai_api_key']
-      const providerType = orgSettings['ai_provider_type'] || (() => { throw new Error('No AI provider configured') })()
-      if (!apiKey) {
+      const resolved = await this.resolveOrgProvider(providerInfo.provider_type)
+      if (!resolved) {
         await this.conversationRepo.updateStatsStatus(statsId, 'failed')
         return
       }
-      const provider = this.providerRegistry.get(providerType)
+      const { provider, apiKey } = resolved
+      const model = providerInfo.model
 
       const durationSec = timestamps?.first_message_at && timestamps?.closed_at
         ? Math.round((new Date(timestamps.closed_at).getTime() - new Date(timestamps.first_message_at).getTime()) / 1000)
@@ -127,20 +126,30 @@ export class LifecycleUseCase {
     }
   }
 
+  private async resolveOrgProvider(workspaceProviderType: string | null): Promise<{ provider: ProviderPlugin; apiKey: string } | null> {
+    const orgSettings = await this.orgRepo.getSettingValues(['ai_provider_type'])
+    const providerType = workspaceProviderType || orgSettings['ai_provider_type']
+    if (!providerType) return null
+
+    const keySettings = await this.orgRepo.getSettingValues([`${providerType}_api_key`, 'ai_api_key'])
+    const apiKey = keySettings[`${providerType}_api_key`] || keySettings['ai_api_key'] || null
+    if (!apiKey) return null
+
+    const provider = this.providerRegistry.get(providerType)
+    return { provider, apiKey }
+  }
+
   private async generateColdMessage(conversationId: string): Promise<string> {
     try {
       const messages = await this.conversationRepo.findMessages(conversationId)
       if (messages.length === 0) return ''
 
-      const coldSettings = await this.orgRepo.getSettingValues(['ai_api_key', 'ai_provider_type'])
-      const apiKey = coldSettings['ai_api_key']
-      const providerType = coldSettings['ai_provider_type'] || (() => { throw new Error('No AI provider configured') })()
-      if (!apiKey) return ''
-
-      const model = await this.conversationRepo.getWorkspaceModel(conversationId)
-      if (!model) return ''
-
-      const provider = this.providerRegistry.get(providerType)
+      const providerInfo = await this.conversationRepo.getWorkspaceProviderInfo(conversationId)
+      if (!providerInfo) return ''
+      const resolved = await this.resolveOrgProvider(providerInfo.provider_type)
+      if (!resolved) return ''
+      const { provider, apiKey } = resolved
+      const model = providerInfo.model
       const transcript = messages.slice(-6).map(m => `${m.role}: ${m.content}`).join('\n\n')
       return provider.createSimpleMessage({
         apiKey,

--- a/src/application/ports/TenantService.ts
+++ b/src/application/ports/TenantService.ts
@@ -26,4 +26,9 @@ export interface TenantService {
    * Returns userOrgId in multi-tenant, or the single org in single-tenant.
    */
   resolveOrgForCreation(userOrgId: string): string
+
+  /**
+   * Whether multiple orgs can be created (cloud = true, self-hosted = false).
+   */
+  allowMultipleOrgs: boolean
 }

--- a/src/application/query/ExecuteQueryUseCase.test.ts
+++ b/src/application/query/ExecuteQueryUseCase.test.ts
@@ -93,11 +93,16 @@ describe('ExecuteQueryUseCase', () => {
       stubWorkspace({ id: 'ws-test', model: 'claude-sonnet-4-20250514' }),
     )
 
-    // Default: org has an AI provider configured
-    vi.mocked(orgRepo.getSettingValues).mockResolvedValue({
-      ai_provider_type: 'anthropic',
-      ai_api_key: 'sk-test-key',
-      anthropic_api_key: '',
+    // Default: org has an AI provider configured (prefixed key pattern)
+    vi.mocked(orgRepo.getSettingValues).mockImplementation(async (keys: string[]) => {
+      const store: Record<string, string> = {
+        ai_provider_type: 'anthropic',
+        anthropic_api_key: 'sk-test-key',
+        ai_api_key: '',
+      }
+      const result: Record<string, string> = {}
+      for (const k of keys) result[k] = store[k] || ''
+      return result
     })
   })
 
@@ -110,11 +115,7 @@ describe('ExecuteQueryUseCase', () => {
   })
 
   it('returns error message when no AI provider is configured', async () => {
-    vi.mocked(orgRepo.getSettingValues).mockResolvedValue({
-      ai_provider_type: '',
-      ai_api_key: '',
-      anthropic_api_key: '',
-    })
+    vi.mocked(orgRepo.getSettingValues).mockResolvedValue({})
     const useCase = buildUseCase()
 
     const result = await useCase.execute('ws-test', 'hello', baseMeta)
@@ -124,10 +125,11 @@ describe('ExecuteQueryUseCase', () => {
   })
 
   it('returns error when API key is missing', async () => {
-    vi.mocked(orgRepo.getSettingValues).mockResolvedValue({
-      ai_provider_type: 'anthropic',
-      ai_api_key: '',
-      anthropic_api_key: '',
+    vi.mocked(orgRepo.getSettingValues).mockImplementation(async (keys: string[]) => {
+      const store: Record<string, string> = { ai_provider_type: 'anthropic' }
+      const result: Record<string, string> = {}
+      for (const k of keys) result[k] = store[k] || ''
+      return result
     })
     const useCase = buildUseCase()
 
@@ -135,6 +137,47 @@ describe('ExecuteQueryUseCase', () => {
 
     expect(result.error).toBe('no_ai_provider_configured')
     expect(result.answer).toBe('no_ai_provider_configured')
+  })
+
+  it('uses workspace provider_type override when set', async () => {
+    vi.mocked(workspaceRepo.findActiveById).mockResolvedValue(
+      stubWorkspace({ id: 'ws-test', model: 'gpt-4o', provider_type: 'openai' }),
+    )
+    vi.mocked(orgRepo.getSettingValues).mockImplementation(async (keys: string[]) => {
+      const store: Record<string, string> = {
+        ai_provider_type: 'anthropic',
+        openai_api_key: 'sk-openai-key',
+        anthropic_api_key: 'sk-anthropic-key',
+      }
+      const result: Record<string, string> = {}
+      for (const k of keys) result[k] = store[k] || ''
+      return result
+    })
+    vi.mocked(workspaceRepo.findConnectionConfigs).mockResolvedValue([])
+    const useCase = buildUseCase()
+
+    await useCase.execute('ws-test', 'hello', baseMeta)
+
+    expect(providerRegistry.get).toHaveBeenCalledWith('openai')
+    expect(provider.setApiKey).toHaveBeenCalledWith('sk-openai-key')
+  })
+
+  it('falls back to legacy ai_api_key when prefixed key is missing', async () => {
+    vi.mocked(orgRepo.getSettingValues).mockImplementation(async (keys: string[]) => {
+      const store: Record<string, string> = {
+        ai_provider_type: 'anthropic',
+        ai_api_key: 'sk-legacy-key',
+      }
+      const result: Record<string, string> = {}
+      for (const k of keys) result[k] = store[k] || ''
+      return result
+    })
+    vi.mocked(workspaceRepo.findConnectionConfigs).mockResolvedValue([])
+    const useCase = buildUseCase()
+
+    await useCase.execute('ws-test', 'hello', baseMeta)
+
+    expect(provider.setApiKey).toHaveBeenCalledWith('sk-legacy-key')
   })
 
   it('runs direct LLM conversation when no tools are discovered', async () => {

--- a/src/application/query/ExecuteQueryUseCase.ts
+++ b/src/application/query/ExecuteQueryUseCase.ts
@@ -116,7 +116,7 @@ export class ExecuteQueryUseCase {
     let provider: ProviderPlugin
     let apiKey: string
     try {
-      const resolved = await this.resolveProvider()
+      const resolved = await this.resolveProvider(workspace.provider_type)
       provider = resolved.provider
       apiKey = resolved.apiKey
     } catch {
@@ -257,11 +257,18 @@ export class ExecuteQueryUseCase {
     }
   }
 
-  private async resolveProvider(): Promise<{ provider: ProviderPlugin; apiKey: string }> {
-    const settings = await this.orgRepo.getSettingValues(['ai_provider_type', 'ai_api_key', 'anthropic_api_key'])
-    const providerType = settings['ai_provider_type'] || (() => { throw new Error('No AI provider configured') })()
-    const apiKey = settings['ai_api_key'] || settings['anthropic_api_key'] || null
+  private async resolveProvider(workspaceProviderType: string | null): Promise<{ provider: ProviderPlugin; apiKey: string }> {
+    // Step 1: resolve which provider type to use (workspace override > org default)
+    const orgSettings = await this.orgRepo.getSettingValues(['ai_provider_type'])
+    const providerType = workspaceProviderType || orgSettings['ai_provider_type']
+    if (!providerType) throw new ConfigurationError('No AI provider configured')
+
+    // Step 2: fetch API key using prefixed key (anthropic_api_key, openai_api_key)
+    // Fall back to legacy ai_api_key for backward compatibility
+    const keySettings = await this.orgRepo.getSettingValues([`${providerType}_api_key`, 'ai_api_key'])
+    const apiKey = keySettings[`${providerType}_api_key`] || keySettings['ai_api_key'] || null
     if (!apiKey) throw new ConfigurationError('No AI API key configured')
+
     const provider = this.providerRegistry.get(providerType)
     return { provider, apiKey }
   }

--- a/src/application/workspace/UpdateWorkspaceUseCase.ts
+++ b/src/application/workspace/UpdateWorkspaceUseCase.ts
@@ -4,6 +4,7 @@ import { NotFoundError } from '../../domain/shared/errors.js'
 interface UpdateWorkspaceInput {
   name?: string
   model?: string
+  provider_type?: string | null
   system_prompt?: string
   cold_timeout_minutes?: number | null
   close_timeout_minutes?: number | null

--- a/src/container.ts
+++ b/src/container.ts
@@ -137,7 +137,7 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
   const requireAuth = createRequireAuth(tokenService)
 
   // Application use cases
-  const signupUseCase = new SignupUseCase(orgRepo, workspaceRepo, passwordService, tokenService)
+  const signupUseCase = new SignupUseCase(orgRepo, workspaceRepo, passwordService, tokenService, tenantService)
   const loginUseCase = new LoginUseCase(orgRepo, passwordService, tokenService)
   const getOrgUseCase = new GetOrgUseCase(orgRepo)
   const updateOrgUseCase = new UpdateOrgUseCase(orgRepo)

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -773,6 +773,16 @@ const migrations: Migration[] = [
       }
     },
   },
+  {
+    version: 28,
+    name: 'workspace provider_type column',
+    up: async (pool) => {
+      const [cols] = await pool.execute<ColumnInfoRow[]>("SHOW COLUMNS FROM workspaces LIKE 'provider_type'");
+      if (cols.length === 0) {
+        await pool.execute(`ALTER TABLE workspaces ADD COLUMN provider_type VARCHAR(50) DEFAULT NULL AFTER model`);
+      }
+    },
+  },
 ];
 
 interface SchemaMigrationRow extends mysql.RowDataPacket {

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -28,6 +28,7 @@ export interface WorkspaceRow extends RowDataPacket {
   name: string
   status: 'active' | 'paused' | 'archived'
   model: string
+  provider_type: string | null
   system_prompt: string | null
   max_tool_rounds: number
   max_thread_history: number

--- a/src/domain/conversation/repository.ts
+++ b/src/domain/conversation/repository.ts
@@ -137,6 +137,7 @@ export interface ConversationRepository {
   getAggregateData(conversationId: string): Promise<ConversationAggregateData>
   getTimestamps(conversationId: string): Promise<{ first_message_at: string | null; closed_at: string | null; message_count: number } | null>
   getWorkspaceModel(conversationId: string): Promise<string | null>
+  getWorkspaceProviderInfo(conversationId: string): Promise<{ model: string; provider_type: string | null } | null>
 
   findColdTransitionCandidates(): Promise<ColdTransitionData[]>
   batchTransitionToCold(ids: string[]): Promise<void>

--- a/src/domain/organisation/repository.ts
+++ b/src/domain/organisation/repository.ts
@@ -29,6 +29,7 @@ export interface TeamData {
 
 export interface OrganisationRepository {
   findById(id: string): Promise<OrgData | null>
+  anyExists(): Promise<boolean>
   create(id: string, name: string, slug: string): Promise<void>
   updateName(id: string, name: string): Promise<void>
 

--- a/src/domain/workspace/repository.ts
+++ b/src/domain/workspace/repository.ts
@@ -5,6 +5,7 @@ export interface WorkspaceData {
   name: string
   status: 'active' | 'paused' | 'archived'
   model: string
+  provider_type: string | null
   system_prompt: string | null
   max_tool_rounds: number
   max_thread_history: number
@@ -120,7 +121,7 @@ export interface WorkspaceRepository {
   findActiveById(id: string): Promise<WorkspaceData | null>
   existsById(id: string): Promise<boolean>
   create(workspace: { id: string; orgId: string | null; teamId: string | null; name: string; model: string; systemPrompt: string; createdBy?: string | null }): Promise<void>
-  update(id: string, fields: { name?: string; model?: string; system_prompt?: string; cold_timeout_minutes?: number | null; close_timeout_minutes?: number | null }): Promise<void>
+  update(id: string, fields: { name?: string; model?: string; provider_type?: string | null; system_prompt?: string; cold_timeout_minutes?: number | null; close_timeout_minutes?: number | null }): Promise<void>
   listNonArchived(orgId: string | null): Promise<WorkspaceListItemData[]>
   getSummary(id: string): Promise<WorkspaceData | null>
 

--- a/src/infrastructure/persistence/mysql/MysqlConversationRepository.ts
+++ b/src/infrastructure/persistence/mysql/MysqlConversationRepository.ts
@@ -20,6 +20,7 @@ interface SeqRow extends RowDataPacket { next_seq: number }
 interface AggRow extends RowDataPacket { ti: number; to2: number; cost: number; dur: number; qcount: number }
 interface TimestampRow extends RowDataPacket { first_message_at: string | null; closed_at: string | null; message_count: number }
 interface ModelRow extends RowDataPacket { model: string }
+interface ProviderInfoRow extends RowDataPacket { model: string; provider_type: string | null }
 interface TicketRow extends RowDataPacket { open_count: number | null; cold_count: number | null; closed_today: number | null; closed_week: number | null }
 interface SentimentRow extends RowDataPacket { sentiment_score: number; cnt: number }
 interface CompStatsRow extends RowDataPacket { compliance_violations: string | null; conversation_id: string; created_at: string }
@@ -227,6 +228,13 @@ export class MysqlConversationRepository implements ConversationRepository {
       'SELECT w.model FROM workspaces w JOIN conversations c ON c.workspace_id = w.id WHERE c.id = ?', [conversationId]
     )
     return rows[0]?.model || null
+  }
+
+  async getWorkspaceProviderInfo(conversationId: string): Promise<{ model: string; provider_type: string | null } | null> {
+    const [rows] = await this.pool.execute<ProviderInfoRow[]>(
+      'SELECT w.model, w.provider_type FROM workspaces w JOIN conversations c ON c.workspace_id = w.id WHERE c.id = ?', [conversationId]
+    )
+    return rows[0] || null
   }
 
   async findColdTransitionCandidates(): Promise<ColdTransitionData[]> {

--- a/src/infrastructure/persistence/mysql/MysqlOrganisationRepository.ts
+++ b/src/infrastructure/persistence/mysql/MysqlOrganisationRepository.ts
@@ -22,6 +22,11 @@ export class MysqlOrganisationRepository implements OrganisationRepository {
     return rows[0] || null
   }
 
+  async anyExists(): Promise<boolean> {
+    const [rows] = await this.pool.execute<CountRow[]>('SELECT COUNT(*) as total FROM organisations')
+    return rows[0].total > 0
+  }
+
   async create(id: string, name: string, slug: string): Promise<void> {
     await this.pool.execute(
       'INSERT INTO organisations (id, name, slug) VALUES (?, ?, ?)', [id, name, slug]

--- a/src/infrastructure/persistence/mysql/MysqlWorkspaceRepository.ts
+++ b/src/infrastructure/persistence/mysql/MysqlWorkspaceRepository.ts
@@ -63,11 +63,19 @@ export class MysqlWorkspaceRepository implements WorkspaceRepository {
     )
   }
 
-  async update(id: string, fields: { name?: string; model?: string; system_prompt?: string; cold_timeout_minutes?: number | null; close_timeout_minutes?: number | null }): Promise<void> {
-    await this.pool.execute(
-      'UPDATE workspaces SET name = COALESCE(?, name), model = COALESCE(?, model), system_prompt = COALESCE(?, system_prompt), cold_timeout_minutes = COALESCE(?, cold_timeout_minutes), close_timeout_minutes = COALESCE(?, close_timeout_minutes), updated_at = NOW() WHERE id = ?',
-      [fields.name || null, fields.model || null, fields.system_prompt ?? null, fields.cold_timeout_minutes || null, fields.close_timeout_minutes || null, id]
-    )
+  async update(id: string, fields: { name?: string; model?: string; provider_type?: string | null; system_prompt?: string; cold_timeout_minutes?: number | null; close_timeout_minutes?: number | null }): Promise<void> {
+    const sets: string[] = []
+    const params: (string | number | null)[] = []
+    if (fields.name !== undefined) { sets.push('name = ?'); params.push(fields.name) }
+    if (fields.model !== undefined) { sets.push('model = ?'); params.push(fields.model) }
+    if (fields.provider_type !== undefined) { sets.push('provider_type = ?'); params.push(fields.provider_type) }
+    if (fields.system_prompt !== undefined) { sets.push('system_prompt = ?'); params.push(fields.system_prompt) }
+    if (fields.cold_timeout_minutes !== undefined) { sets.push('cold_timeout_minutes = ?'); params.push(fields.cold_timeout_minutes) }
+    if (fields.close_timeout_minutes !== undefined) { sets.push('close_timeout_minutes = ?'); params.push(fields.close_timeout_minutes) }
+    if (sets.length === 0) return
+    sets.push('updated_at = NOW()')
+    params.push(id)
+    await this.pool.execute(`UPDATE workspaces SET ${sets.join(', ')} WHERE id = ?`, params)
   }
 
   async listNonArchived(orgId: string | null): Promise<WorkspaceListItemData[]> {

--- a/src/infrastructure/tenant/CloudTenantService.test.ts
+++ b/src/infrastructure/tenant/CloudTenantService.test.ts
@@ -7,6 +7,8 @@ import { describe, it, expect } from 'vitest'
  */
 
 class CloudTenantServiceLocal {
+  readonly allowMultipleOrgs = true
+
   scopeWorkspaceList(userOrgId: string): string {
     return userOrgId
   }

--- a/src/infrastructure/tenant/NoOpTenantService.ts
+++ b/src/infrastructure/tenant/NoOpTenantService.ts
@@ -7,6 +7,8 @@ import type { TenantService } from '../../application/ports/TenantService.js'
  * are visible, no access checks, creation uses the user's org.
  */
 export class NoOpTenantService implements TenantService {
+  readonly allowMultipleOrgs = false
+
   scopeWorkspaceList(_userOrgId: string): string | null {
     return null // No filtering; show all workspaces
   }

--- a/src/presentation/routes/workspaces.ts
+++ b/src/presentation/routes/workspaces.ts
@@ -40,6 +40,7 @@ const createWorkspaceSchema = z.object({
 const updateWorkspaceSchema = z.object({
   name: z.string().min(1).max(MAX_WORKSPACE_NAME_LENGTH).optional(),
   model: z.string().min(1).max(MAX_WORKSPACE_NAME_LENGTH).optional(),
+  provider_type: z.string().min(1).max(50).nullable().optional(),
   system_prompt: z.string().max(MAX_SYSTEM_PROMPT_LENGTH).optional(),
   cold_timeout_minutes: z.number().int().min(1).max(MAX_TIMEOUT_MINUTES).nullable().optional(),
   close_timeout_minutes: z.number().int().min(1).max(MAX_TIMEOUT_MINUTES).nullable().optional(),


### PR DESCRIPTION
## Summary
- Workspaces can override org default AI provider via `provider_type` column
- Provider credentials stored independently with prefixed keys (`anthropic_api_key`, `openai_api_key`)
- Server resolves provider at query time: workspace override > org default > legacy fallback
- Single-tenant signup guard: rejects second org creation in self-hosted mode
- Migration 28: adds `provider_type` column to workspaces

## Test plan
- [x] 360 tests passing (2 new: single-tenant guard, multi-tenant allows signup)
- [x] Workspace provider override test: uses openai when workspace.provider_type = openai
- [x] Legacy fallback test: uses ai_api_key when prefixed key missing
- [ ] Manual: verify workspace settings save provider_type via dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)