### PR TITLE
refactor: extract row mappers and fix test type casts

### DIFF
--- a/src/__tests__/mocks.ts
+++ b/src/__tests__/mocks.ts
@@ -17,6 +17,8 @@ import type { GuardrailEventRepository } from '../domain/guardrail/repository.js
 import type { GuardrailPolicyRepository } from '../domain/guardrail/policyRepository.js'
 import type { InstalledGuardrailRepository } from '../domain/guardrail/installedGuardrailRepository.js'
 import type { TenantService } from '../application/ports/TenantService.js'
+import type { ManageConversationUseCase } from '../application/conversation/ManageConversationUseCase.js'
+import type { registry as ProviderRegistryInstance, ProviderPlugin } from '@supaproxy/providers'
 
 // ── Stub data ──
 
@@ -347,4 +349,28 @@ export function mockEntryPointRepo(): EntryPointRepository {
     delete: vi.fn().mockResolvedValue(undefined),
     findByOrg: vi.fn().mockResolvedValue([]),
   }
+}
+
+export function mockManageConversationUseCase(): Pick<ManageConversationUseCase, 'recordMessage' | 'getHistory' | 'findOrCreate' | 'setRouting'> {
+  return {
+    recordMessage: vi.fn().mockResolvedValue(undefined),
+    getHistory: vi.fn().mockResolvedValue([]),
+    findOrCreate: vi.fn().mockResolvedValue('conv-1'),
+    setRouting: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+export function mockProviderRegistry(
+  plugins: Array<Pick<ProviderPlugin, 'type' | 'models'> & Partial<ProviderPlugin>> = [],
+): typeof ProviderRegistryInstance {
+  const fullPlugins = plugins as ProviderPlugin[]
+  return {
+    plugins: new Map(fullPlugins.map(p => [p.type, p])),
+    register: vi.fn(),
+    get: vi.fn().mockImplementation((type: string) => fullPlugins.find(p => p.type === type)),
+    has: vi.fn().mockImplementation((type: string) => fullPlugins.some(p => p.type === type)),
+    types: vi.fn().mockReturnValue(fullPlugins.map(p => p.type)),
+    list: vi.fn().mockReturnValue(fullPlugins),
+    schemas: vi.fn().mockReturnValue([]),
+  } as unknown as typeof ProviderRegistryInstance
 }

--- a/src/application/routing/RouteMessageUseCase.test.ts
+++ b/src/application/routing/RouteMessageUseCase.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mockOrgRepo, mockWorkspaceRepo, mockConversationRepo, stubWorkspace } from '../../__tests__/mocks.js'
+import { mockOrgRepo, mockWorkspaceRepo, mockConversationRepo, mockManageConversationUseCase, stubWorkspace } from '../../__tests__/mocks.js'
 import { RouteMessageUseCase } from './RouteMessageUseCase.js'
 import type { SessionStore } from '../ports/SessionStore.js'
 import type { ExecuteQueryUseCase } from '../query/ExecuteQueryUseCase.js'
+import type { ManageConversationUseCase } from '../conversation/ManageConversationUseCase.js'
 
 function mockSessionStore(): SessionStore {
   return {
@@ -50,7 +51,7 @@ describe('RouteMessageUseCase', () => {
     workspaceRepo = mockWorkspaceRepo()
     sessionStore = mockSessionStore()
     executeQuery = mockExecuteQuery()
-    useCase = new RouteMessageUseCase(workspaceRepo, orgRepo, mockConversationRepo(), sessionStore, executeQuery, { recordMessage: vi.fn(), getHistory: vi.fn().mockResolvedValue([]), findOrCreate: vi.fn(), setRouting: vi.fn() } as any)
+    useCase = new RouteMessageUseCase(workspaceRepo, orgRepo, mockConversationRepo(), sessionStore, executeQuery, mockManageConversationUseCase() as ManageConversationUseCase)
   })
 
   it('uses existing session to route directly to workspace', async () => {
@@ -356,7 +357,7 @@ describe('RouteMessageUseCase', () => {
 
   it('records routing metadata on conversation when routing happens', async () => {
     const conversationRepo = mockConversationRepo()
-    const localUseCase = new RouteMessageUseCase(workspaceRepo, orgRepo, conversationRepo, sessionStore, executeQuery, { recordMessage: vi.fn(), getHistory: vi.fn().mockResolvedValue([]), findOrCreate: vi.fn(), setRouting: vi.fn() } as any)
+    const localUseCase = new RouteMessageUseCase(workspaceRepo, orgRepo, conversationRepo, sessionStore, executeQuery, mockManageConversationUseCase() as ManageConversationUseCase)
 
     const defaultWs = stubWorkspace({ id: 'ws-general', name: '#general', is_default: true })
     const targetWs = stubWorkspace({ id: 'ws-insurance', name: 'Insurance' })
@@ -462,15 +463,10 @@ describe('RouteMessageUseCase', () => {
   })
 
   it('logs messages to #general master conversation after routing', async () => {
-    const mockConvUseCase = {
-      recordMessage: vi.fn(),
-      getHistory: vi.fn().mockResolvedValue([]),
-      findOrCreate: vi.fn(),
-      setRouting: vi.fn(),
-    }
+    const mockConvUseCase = mockManageConversationUseCase()
 
     const localUseCase = new RouteMessageUseCase(
-      workspaceRepo, orgRepo, mockConversationRepo(), sessionStore, executeQuery, mockConvUseCase as any,
+      workspaceRepo, orgRepo, mockConversationRepo(), sessionStore, executeQuery, mockConvUseCase as ManageConversationUseCase,
     )
 
     // Session on target workspace with generalConversationId set
@@ -505,18 +501,14 @@ describe('RouteMessageUseCase', () => {
   })
 
   it('passes prior history from receptionist to target workspace', async () => {
-    const mockConvUseCase = {
-      recordMessage: vi.fn(),
-      getHistory: vi.fn().mockResolvedValue([
-        { role: 'user', content: 'I need insurance help' },
-        { role: 'assistant', content: 'Connecting you to Insurance.' },
-      ]),
-      findOrCreate: vi.fn(),
-      setRouting: vi.fn(),
-    }
+    const mockConvUseCase = mockManageConversationUseCase()
+    vi.mocked(mockConvUseCase.getHistory).mockResolvedValue([
+      { role: 'user', content: 'I need insurance help' },
+      { role: 'assistant', content: 'Connecting you to Insurance.' },
+    ])
 
     const localUseCase = new RouteMessageUseCase(
-      workspaceRepo, orgRepo, mockConversationRepo(), sessionStore, executeQuery, mockConvUseCase as any,
+      workspaceRepo, orgRepo, mockConversationRepo(), sessionStore, executeQuery, mockConvUseCase as ManageConversationUseCase,
     )
 
     // Session already routed to insurance with receptionist conversation ID

--- a/src/application/workspace/GetHealthUseCase.test.ts
+++ b/src/application/workspace/GetHealthUseCase.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { mockOrgRepo, mockWorkspaceRepo } from '../../__tests__/mocks.js'
+import { mockOrgRepo, mockWorkspaceRepo, mockProviderRegistry } from '../../__tests__/mocks.js'
 import { GetHealthUseCase } from './GetHealthUseCase.js'
 
 describe('GetHealthUseCase', () => {
@@ -41,12 +41,10 @@ describe('GetHealthUseCase', () => {
   it('detects provider-specific keys via registry', async () => {
     const orgRepo = mockOrgRepo()
     const wsRepo = mockWorkspaceRepo()
-    const mockRegistry = {
-      types: () => ['openai'],
-      get: () => ({ supportsEmbedding: true }),
-      list: () => [{ supportsEmbedding: true }],
-    }
-    const uc = new GetHealthUseCase(orgRepo, wsRepo, mockRegistry as any)
+    const registry = mockProviderRegistry([
+      { type: 'openai', models: [], supportsEmbedding: true },
+    ])
+    const uc = new GetHealthUseCase(orgRepo, wsRepo, registry)
 
     // No general key, but openai_api_key exists
     vi.mocked(orgRepo.getSettingValue).mockImplementation(async (key: string) => {

--- a/src/application/workspace/GetModelsUseCase.test.ts
+++ b/src/application/workspace/GetModelsUseCase.test.ts
@@ -1,18 +1,16 @@
 import { describe, it, expect, vi } from 'vitest'
-import { mockModelRepo, mockOrgRepo } from '../../__tests__/mocks.js'
+import { mockModelRepo, mockOrgRepo, mockProviderRegistry } from '../../__tests__/mocks.js'
 import { GetModelsUseCase } from './GetModelsUseCase.js'
 
 describe('GetModelsUseCase', () => {
   it('returns registry models merged with DB models', async () => {
     const modelRepo = mockModelRepo()
     const orgRepo = mockOrgRepo()
-    const mockRegistry = {
-      list: () => [
-        { type: 'anthropic', models: [{ id: 'claude-sonnet', label: 'Claude Sonnet', default: true }] },
-        { type: 'openai', models: [{ id: 'gpt-4o', label: 'GPT-4o', default: true }] },
-      ],
-    }
-    const uc = new GetModelsUseCase(modelRepo, orgRepo, mockRegistry as any)
+    const registry = mockProviderRegistry([
+      { type: 'anthropic', models: [{ id: 'claude-sonnet', label: 'Claude Sonnet', default: true }] },
+      { type: 'openai', models: [{ id: 'gpt-4o', label: 'GPT-4o', default: true }] },
+    ])
+    const uc = new GetModelsUseCase(modelRepo, orgRepo, registry)
 
     vi.mocked(orgRepo.getSettingValue).mockResolvedValue(null)
     vi.mocked(modelRepo.listAll).mockResolvedValue([
@@ -30,12 +28,10 @@ describe('GetModelsUseCase', () => {
   it('deduplicates registry and DB models', async () => {
     const modelRepo = mockModelRepo()
     const orgRepo = mockOrgRepo()
-    const mockRegistry = {
-      list: () => [
-        { type: 'anthropic', models: [{ id: 'claude-sonnet', label: 'Claude Sonnet' }] },
-      ],
-    }
-    const uc = new GetModelsUseCase(modelRepo, orgRepo, mockRegistry as any)
+    const registry = mockProviderRegistry([
+      { type: 'anthropic', models: [{ id: 'claude-sonnet', label: 'Claude Sonnet' }] },
+    ])
+    const uc = new GetModelsUseCase(modelRepo, orgRepo, registry)
 
     vi.mocked(orgRepo.getSettingValue).mockResolvedValue(null)
     vi.mocked(modelRepo.listAll).mockResolvedValue([
@@ -51,15 +47,13 @@ describe('GetModelsUseCase', () => {
   it('marks default model from org settings', async () => {
     const modelRepo = mockModelRepo()
     const orgRepo = mockOrgRepo()
-    const mockRegistry = {
-      list: () => [
-        { type: 'openai', models: [
-          { id: 'gpt-4o', label: 'GPT-4o' },
-          { id: 'gpt-4o-mini', label: 'GPT-4o Mini' },
-        ] },
-      ],
-    }
-    const uc = new GetModelsUseCase(modelRepo, orgRepo, mockRegistry as any)
+    const registry = mockProviderRegistry([
+      { type: 'openai', models: [
+        { id: 'gpt-4o', label: 'GPT-4o' },
+        { id: 'gpt-4o-mini', label: 'GPT-4o Mini' },
+      ] },
+    ])
+    const uc = new GetModelsUseCase(modelRepo, orgRepo, registry)
 
     vi.mocked(orgRepo.getSettingValue).mockResolvedValue('gpt-4o-mini')
     vi.mocked(modelRepo.listAll).mockResolvedValue([])

--- a/src/infrastructure/persistence/mysql/ConversationRowMappers.ts
+++ b/src/infrastructure/persistence/mysql/ConversationRowMappers.ts
@@ -1,0 +1,77 @@
+import type { RowDataPacket } from 'mysql2'
+import type {
+  ConversationData, ConversationWithStatsData,
+  MessageWithAuditData, ConversationStatsData, ConversationFilterData,
+  ColdTransitionData, ConversationAggregateData,
+} from '../../../domain/conversation/repository.js'
+
+export interface ConvRow extends RowDataPacket, ConversationData {}
+export interface ConvWithStatsRow extends RowDataPacket, ConversationWithStatsData {}
+export interface MsgRow extends RowDataPacket { role: string; content: string }
+export interface MsgAuditRow extends RowDataPacket, MessageWithAuditData {}
+export interface StatsRow extends RowDataPacket, ConversationStatsData {}
+export interface FilterRow extends RowDataPacket { status: string | null; consumer_type: string | null; category: string | null; resolution_status: string | null }
+export interface ColdRow extends RowDataPacket, ColdTransitionData {}
+export interface IdRow extends RowDataPacket { id: string }
+export interface TotalRow extends RowDataPacket { total: number }
+export interface SeqRow extends RowDataPacket { next_seq: number }
+export interface AggRow extends RowDataPacket { ti: number; to2: number; cost: number; dur: number; qcount: number }
+export interface TimestampRow extends RowDataPacket { first_message_at: string | null; closed_at: string | null; message_count: number }
+export interface ModelRow extends RowDataPacket { model: string }
+export interface ProviderInfoRow extends RowDataPacket { model: string; provider_type: string | null }
+export interface TicketRow extends RowDataPacket { open_count: number | null; cold_count: number | null; closed_today: number | null; closed_week: number | null }
+export interface SentimentRow extends RowDataPacket { sentiment_score: number; cnt: number }
+export interface CompStatsRow extends RowDataPacket { compliance_violations: string | null; conversation_id: string; created_at: string }
+export interface GapStatsRow extends RowDataPacket { knowledge_gaps: string | null; created_at: string }
+export interface GapWorkspaceRow extends RowDataPacket { knowledge_gaps: string | null; conversation_id: string; user_name: string | null; last_activity_at: string | null }
+export interface ViolationWorkspaceRow extends RowDataPacket { compliance_violations: string | null; conversation_id: string; user_name: string | null; last_activity_at: string | null }
+export interface ResRow extends RowDataPacket { resolution_status: string; cnt: number }
+export interface CatRow extends RowDataPacket { category: string; cnt: number }
+export interface ChanRow extends RowDataPacket { consumer_type: string; cnt: number }
+export interface CostRow extends RowDataPacket { cost_today: number; cost_week: number; cost_month: number; q_today: number; q_week: number; q_month: number }
+
+export function mapAggregateRow(row: AggRow): ConversationAggregateData {
+  return {
+    total_tokens_input: row.ti,
+    total_tokens_output: row.to2,
+    total_cost_usd: row.cost,
+    total_duration_ms: row.dur,
+    query_count: row.qcount,
+  }
+}
+
+export function mapTicketRow(row: TicketRow): { open: number; cold: number; closed_today: number; closed_week: number } {
+  return {
+    open: Number(row.open_count) || 0,
+    cold: Number(row.cold_count) || 0,
+    closed_today: Number(row.closed_today) || 0,
+    closed_week: Number(row.closed_week) || 0,
+  }
+}
+
+export function mapSentimentRow(row: SentimentRow): { score: number; count: number } {
+  return { score: row.sentiment_score, count: row.cnt }
+}
+
+export function mapResolutionRow(row: ResRow): { status: string; count: number } {
+  return { status: row.resolution_status, count: row.cnt }
+}
+
+export function mapCategoryRow(row: CatRow): { category: string; count: number } {
+  return { category: row.category, count: row.cnt }
+}
+
+export function mapChannelRow(row: ChanRow): { consumer_type: string; count: number } {
+  return { consumer_type: row.consumer_type, count: row.cnt }
+}
+
+export function mapFilterRows(rows: FilterRow[]): ConversationFilterData {
+  const filters: ConversationFilterData = { status: [], consumer: [], category: [], resolution: [] }
+  for (const r of rows) {
+    if (r.status && !filters.status.includes(r.status)) filters.status.push(r.status)
+    if (r.consumer_type && !filters.consumer.includes(r.consumer_type)) filters.consumer.push(r.consumer_type)
+    if (r.category && !filters.category.includes(r.category)) filters.category.push(r.category)
+    if (r.resolution_status && !filters.resolution.includes(r.resolution_status)) filters.resolution.push(r.resolution_status)
+  }
+  return filters
+}

--- a/src/infrastructure/persistence/mysql/GuardrailPolicyRowMappers.ts
+++ b/src/infrastructure/persistence/mysql/GuardrailPolicyRowMappers.ts
@@ -1,0 +1,150 @@
+import type mysql from 'mysql2/promise'
+import type {
+  GuardrailPolicyData,
+  GuardrailPolicyOverrideData,
+  PolicyComplianceRow,
+  SecurityOverviewStats,
+} from '../../../domain/guardrail/policyRepository.js'
+
+export interface PolicyRow extends mysql.RowDataPacket {
+  id: string
+  org_id: string
+  plugin_id: string
+  enforcement: string
+  created_at: string
+  updated_at: string
+}
+
+export interface OverrideRow extends mysql.RowDataPacket {
+  id: string
+  policy_id: string
+  workspace_id: string
+  justification: string
+  created_by: string
+  created_at: string
+}
+
+export interface ComplianceRow extends mysql.RowDataPacket {
+  workspace_id: string
+  workspace_name: string
+  enabled: number
+  has_override: number
+  is_default: number
+}
+
+export interface CountRow extends mysql.RowDataPacket {
+  total: number
+}
+
+export interface EventCountRow extends mysql.RowDataPacket {
+  blocked_events: number
+  stripped_events: number
+  flagged_events: number
+}
+
+export interface DayRow extends mysql.RowDataPacket {
+  date: string
+  blocked: number
+  stripped: number
+}
+
+export interface TopWorkspaceRow extends mysql.RowDataPacket {
+  workspace_id: string
+  workspace_name: string
+  event_count: number
+}
+
+export interface FlaggedRow extends mysql.RowDataPacket {
+  id: string
+  workspace_id: string
+  workspace_name: string
+  event_type: string
+  plugin_id: string
+  status: string
+  created_at: string
+}
+
+export interface PluginRow extends mysql.RowDataPacket {
+  plugin_id: string
+}
+
+export interface OverridePluginRow extends mysql.RowDataPacket {
+  plugin_id: string
+}
+
+export function mapPolicyRow(r: PolicyRow): GuardrailPolicyData {
+  return {
+    id: r.id,
+    org_id: r.org_id,
+    plugin_id: r.plugin_id,
+    enforcement: r.enforcement as GuardrailPolicyData['enforcement'],
+    created_at: r.created_at,
+    updated_at: r.updated_at,
+  }
+}
+
+export function mapOverrideRow(r: OverrideRow): GuardrailPolicyOverrideData {
+  return {
+    id: r.id,
+    policy_id: r.policy_id,
+    workspace_id: r.workspace_id,
+    justification: r.justification,
+    created_by: r.created_by,
+    created_at: r.created_at,
+  }
+}
+
+export function mapComplianceRow(r: ComplianceRow): PolicyComplianceRow {
+  return {
+    workspace_id: r.workspace_id,
+    workspace_name: r.workspace_name,
+    enabled: r.enabled === 1,
+    has_override: r.has_override === 1,
+    is_default: r.is_default === 1,
+  }
+}
+
+export function mapSecurityOverviewResults(
+  eventCounts: EventCountRow[],
+  dayRows: DayRow[],
+  topWorkspaces: TopWorkspaceRow[],
+  flaggedRows: FlaggedRow[],
+  wsCountRows: CountRow[],
+  compliantRows: CountRow[],
+): SecurityOverviewStats {
+  const ec = eventCounts[0]
+  const blocked = Number(ec?.blocked_events ?? 0)
+  const stripped = Number(ec?.stripped_events ?? 0)
+  const flagged = Number(ec?.flagged_events ?? 0)
+  const totalWs = Number(wsCountRows[0]?.total ?? 0)
+  const compliantWs = Number(compliantRows[0]?.total ?? 0)
+
+  return {
+    total_events: blocked + stripped,
+    blocked_events: blocked,
+    stripped_events: stripped,
+    flagged_events: flagged,
+    events_by_day: dayRows.map(r => ({
+      date: typeof r.date === 'string' ? r.date : String(r.date),
+      blocked: Number(r.blocked),
+      stripped: Number(r.stripped),
+    })),
+    top_workspaces: topWorkspaces.map(r => ({
+      workspace_id: r.workspace_id,
+      workspace_name: r.workspace_name,
+      event_count: Number(r.event_count),
+    })),
+    recent_flagged: flaggedRows.map(r => ({
+      id: r.id,
+      workspace_id: r.workspace_id,
+      workspace_name: r.workspace_name,
+      event_type: r.event_type,
+      plugin_id: r.plugin_id,
+      status: r.status,
+      created_at: r.created_at,
+    })),
+    compliance_score: totalWs > 0 ? Math.round((compliantWs / totalWs) * 100) : 100,
+    total_workspaces: totalWs,
+    compliant_workspaces: compliantWs,
+  }
+}

--- a/src/infrastructure/persistence/mysql/MysqlConversationRepository.ts
+++ b/src/infrastructure/persistence/mysql/MysqlConversationRepository.ts
@@ -1,36 +1,20 @@
 import type mysql from 'mysql2/promise'
-import type { RowDataPacket } from 'mysql2'
 import type {
   ConversationRepository, ConversationData, ConversationWithStatsData,
   MessageWithAuditData, ConversationStatsData, ConversationFilterData,
   ColdTransitionData, ConversationAggregateData,
 } from '../../../domain/conversation/repository.js'
 import { STATUS_OPEN, STATUS_CLOSED, STATUS_PENDING } from '../../../defaults.js'
-
-interface ConvRow extends RowDataPacket, ConversationData {}
-interface ConvWithStatsRow extends RowDataPacket, ConversationWithStatsData {}
-interface MsgRow extends RowDataPacket { role: string; content: string }
-interface MsgAuditRow extends RowDataPacket, MessageWithAuditData {}
-interface StatsRow extends RowDataPacket, ConversationStatsData {}
-interface FilterRow extends RowDataPacket { status: string | null; consumer_type: string | null; category: string | null; resolution_status: string | null }
-interface ColdRow extends RowDataPacket, ColdTransitionData {}
-interface IdRow extends RowDataPacket { id: string }
-interface TotalRow extends RowDataPacket { total: number }
-interface SeqRow extends RowDataPacket { next_seq: number }
-interface AggRow extends RowDataPacket { ti: number; to2: number; cost: number; dur: number; qcount: number }
-interface TimestampRow extends RowDataPacket { first_message_at: string | null; closed_at: string | null; message_count: number }
-interface ModelRow extends RowDataPacket { model: string }
-interface ProviderInfoRow extends RowDataPacket { model: string; provider_type: string | null }
-interface TicketRow extends RowDataPacket { open_count: number | null; cold_count: number | null; closed_today: number | null; closed_week: number | null }
-interface SentimentRow extends RowDataPacket { sentiment_score: number; cnt: number }
-interface CompStatsRow extends RowDataPacket { compliance_violations: string | null; conversation_id: string; created_at: string }
-interface GapStatsRow extends RowDataPacket { knowledge_gaps: string | null; created_at: string }
-interface GapWorkspaceRow extends RowDataPacket { knowledge_gaps: string | null; conversation_id: string; user_name: string | null; last_activity_at: string | null }
-interface ViolationWorkspaceRow extends RowDataPacket { compliance_violations: string | null; conversation_id: string; user_name: string | null; last_activity_at: string | null }
-interface ResRow extends RowDataPacket { resolution_status: string; cnt: number }
-interface CatRow extends RowDataPacket { category: string; cnt: number }
-interface ChanRow extends RowDataPacket { consumer_type: string; cnt: number }
-interface CostRow extends RowDataPacket { cost_today: number; cost_week: number; cost_month: number; q_today: number; q_week: number; q_month: number }
+import {
+  type ConvRow, type ConvWithStatsRow, type MsgRow, type MsgAuditRow,
+  type StatsRow, type FilterRow, type ColdRow, type IdRow, type TotalRow,
+  type SeqRow, type AggRow, type TimestampRow, type ModelRow, type ProviderInfoRow,
+  type TicketRow, type SentimentRow, type CompStatsRow, type GapStatsRow,
+  type GapWorkspaceRow, type ViolationWorkspaceRow, type ResRow, type CatRow,
+  type ChanRow, type CostRow,
+  mapAggregateRow, mapTicketRow, mapSentimentRow, mapResolutionRow,
+  mapCategoryRow, mapChannelRow, mapFilterRows,
+} from './ConversationRowMappers.js'
 
 export class MysqlConversationRepository implements ConversationRepository {
   constructor(private readonly pool: mysql.Pool) {}
@@ -123,14 +107,7 @@ export class MysqlConversationRepository implements ConversationRepository {
       WHERE c.workspace_id = ?
     `, [workspaceId])
 
-    const filters: ConversationFilterData = { status: [], consumer: [], category: [], resolution: [] }
-    for (const r of filterRows) {
-      if (r.status && !filters.status.includes(r.status)) filters.status.push(r.status)
-      if (r.consumer_type && !filters.consumer.includes(r.consumer_type)) filters.consumer.push(r.consumer_type)
-      if (r.category && !filters.category.includes(r.category)) filters.category.push(r.category)
-      if (r.resolution_status && !filters.resolution.includes(r.resolution_status)) filters.resolution.push(r.resolution_status)
-    }
-    return filters
+    return mapFilterRows(filterRows)
   }
 
   async findMessages(conversationId: string): Promise<Array<{ role: 'user' | 'assistant'; content: string }>> {
@@ -213,7 +190,7 @@ export class MysqlConversationRepository implements ConversationRepository {
               COALESCE(SUM(cost_usd), 0) as cost, COALESCE(SUM(duration_ms), 0) as dur, COUNT(*) as qcount
        FROM audit_logs WHERE conversation_id = ?`, [conversationId]
     )
-    return { total_tokens_input: rows[0].ti, total_tokens_output: rows[0].to2, total_cost_usd: rows[0].cost, total_duration_ms: rows[0].dur, query_count: rows[0].qcount }
+    return mapAggregateRow(rows[0])
   }
 
   async getTimestamps(conversationId: string): Promise<{ first_message_at: string | null; closed_at: string | null; message_count: number } | null> {
@@ -276,8 +253,7 @@ export class MysqlConversationRepository implements ConversationRepository {
         SUM(status = '${STATUS_CLOSED}' AND closed_at > NOW() - INTERVAL 7 DAY) as closed_week
       FROM conversations WHERE workspace_id = ?
     `, [workspaceId])
-    const t = rows[0] || {}
-    return { open: Number(t.open_count) || 0, cold: Number(t.cold_count) || 0, closed_today: Number(t.closed_today) || 0, closed_week: Number(t.closed_week) || 0 }
+    return mapTicketRow(rows[0] || {} as TicketRow)
   }
 
   async getSentimentDistribution(workspaceId: string): Promise<Array<{ score: number; count: number }>> {
@@ -287,7 +263,7 @@ export class MysqlConversationRepository implements ConversationRepository {
       WHERE c.workspace_id = ? AND cs.stats_status = 'complete' AND cs.sentiment_score IS NOT NULL
       GROUP BY cs.sentiment_score
     `, [workspaceId])
-    return rows.map(r => ({ score: r.sentiment_score, count: r.cnt }))
+    return rows.map(mapSentimentRow)
   }
 
   async getComplianceStats(workspaceId: string, limit: number): Promise<Array<{ compliance_violations: string | null; conversation_id: string; created_at: string }>> {
@@ -337,7 +313,7 @@ export class MysqlConversationRepository implements ConversationRepository {
       WHERE c.workspace_id = ? AND cs.stats_status = 'complete'
       GROUP BY cs.resolution_status
     `, [workspaceId])
-    return rows.map(r => ({ status: r.resolution_status, count: r.cnt }))
+    return rows.map(mapResolutionRow)
   }
 
   async getCategoryDistribution(workspaceId: string): Promise<Array<{ category: string; count: number }>> {
@@ -347,7 +323,7 @@ export class MysqlConversationRepository implements ConversationRepository {
       WHERE c.workspace_id = ? AND cs.stats_status = 'complete' AND cs.category IS NOT NULL
       GROUP BY cs.category ORDER BY cnt DESC
     `, [workspaceId])
-    return rows.map(r => ({ category: r.category, count: r.cnt }))
+    return rows.map(mapCategoryRow)
   }
 
   async getChannelDistribution(workspaceId: string): Promise<Array<{ consumer_type: string; count: number }>> {
@@ -355,7 +331,7 @@ export class MysqlConversationRepository implements ConversationRepository {
       SELECT consumer_type, COUNT(*) as cnt FROM conversations WHERE workspace_id = ?
       GROUP BY consumer_type ORDER BY cnt DESC
     `, [workspaceId])
-    return rows.map(r => ({ consumer_type: r.consumer_type, count: r.cnt }))
+    return rows.map(mapChannelRow)
   }
 
   async getCostAndUsage(workspaceId: string): Promise<{ cost_today: number; cost_week: number; cost_month: number; q_today: number; q_week: number; q_month: number }> {

--- a/src/infrastructure/persistence/mysql/MysqlGuardrailPolicyRepository.ts
+++ b/src/infrastructure/persistence/mysql/MysqlGuardrailPolicyRepository.ts
@@ -7,72 +7,12 @@ import type {
   SecurityOverviewStats,
 } from '../../../domain/guardrail/policyRepository.js'
 import { DEFAULT_SECURITY_TOP_WORKSPACES, DEFAULT_SECURITY_RECENT_EVENTS } from '../../../defaults.js'
-
-interface PolicyRow extends mysql.RowDataPacket {
-  id: string
-  org_id: string
-  plugin_id: string
-  enforcement: string
-  created_at: string
-  updated_at: string
-}
-
-interface OverrideRow extends mysql.RowDataPacket {
-  id: string
-  policy_id: string
-  workspace_id: string
-  justification: string
-  created_by: string
-  created_at: string
-}
-
-interface ComplianceRow extends mysql.RowDataPacket {
-  workspace_id: string
-  workspace_name: string
-  enabled: number
-  has_override: number
-  is_default: number
-}
-
-interface CountRow extends mysql.RowDataPacket {
-  total: number
-}
-
-interface EventCountRow extends mysql.RowDataPacket {
-  blocked_events: number
-  stripped_events: number
-  flagged_events: number
-}
-
-interface DayRow extends mysql.RowDataPacket {
-  date: string
-  blocked: number
-  stripped: number
-}
-
-interface TopWorkspaceRow extends mysql.RowDataPacket {
-  workspace_id: string
-  workspace_name: string
-  event_count: number
-}
-
-interface FlaggedRow extends mysql.RowDataPacket {
-  id: string
-  workspace_id: string
-  workspace_name: string
-  event_type: string
-  plugin_id: string
-  status: string
-  created_at: string
-}
-
-interface PluginRow extends mysql.RowDataPacket {
-  plugin_id: string
-}
-
-interface OverridePluginRow extends mysql.RowDataPacket {
-  plugin_id: string
-}
+import {
+  type PolicyRow, type OverrideRow, type ComplianceRow,
+  type CountRow, type EventCountRow, type DayRow,
+  type TopWorkspaceRow, type FlaggedRow, type PluginRow, type OverridePluginRow,
+  mapPolicyRow, mapOverrideRow, mapComplianceRow, mapSecurityOverviewResults,
+} from './GuardrailPolicyRowMappers.js'
 
 export class MysqlGuardrailPolicyRepository implements GuardrailPolicyRepository {
   constructor(private readonly pool: mysql.Pool) {}
@@ -125,13 +65,7 @@ export class MysqlGuardrailPolicyRepository implements GuardrailPolicyRepository
        ORDER BY w.name`,
       params,
     )
-    return rows.map(r => ({
-      workspace_id: r.workspace_id,
-      workspace_name: r.workspace_name,
-      enabled: r.enabled === 1,
-      has_override: r.has_override === 1,
-      is_default: r.is_default === 1,
-    }))
+    return rows.map(mapComplianceRow)
   }
 
   async findOverride(policyId: string, workspaceId: string): Promise<GuardrailPolicyOverrideData | null> {
@@ -159,7 +93,6 @@ export class MysqlGuardrailPolicyRepository implements GuardrailPolicyRepository
   async getOrgEventStats(orgId: string, days: number): Promise<SecurityOverviewStats> {
     const dateCutoff = `DATE_SUB(NOW(), INTERVAL ${days} DAY)`
 
-    // All these queries join through workspaces to scope by org_id
     const [
       [eventCounts],
       [dayRows],
@@ -229,41 +162,7 @@ export class MysqlGuardrailPolicyRepository implements GuardrailPolicyRepository
       ),
     ])
 
-    const ec = eventCounts[0]
-    const blocked = Number(ec?.blocked_events ?? 0)
-    const stripped = Number(ec?.stripped_events ?? 0)
-    const flagged = Number(ec?.flagged_events ?? 0)
-    const totalWs = Number(wsCountRows[0]?.total ?? 0)
-    const compliantWs = Number(compliantRows[0]?.total ?? 0)
-
-    return {
-      total_events: blocked + stripped,
-      blocked_events: blocked,
-      stripped_events: stripped,
-      flagged_events: flagged,
-      events_by_day: dayRows.map(r => ({
-        date: typeof r.date === 'string' ? r.date : String(r.date),
-        blocked: Number(r.blocked),
-        stripped: Number(r.stripped),
-      })),
-      top_workspaces: topWorkspaces.map(r => ({
-        workspace_id: r.workspace_id,
-        workspace_name: r.workspace_name,
-        event_count: Number(r.event_count),
-      })),
-      recent_flagged: flaggedRows.map(r => ({
-        id: r.id,
-        workspace_id: r.workspace_id,
-        workspace_name: r.workspace_name,
-        event_type: r.event_type,
-        plugin_id: r.plugin_id,
-        status: r.status,
-        created_at: r.created_at,
-      })),
-      compliance_score: totalWs > 0 ? Math.round((compliantWs / totalWs) * 100) : 100,
-      total_workspaces: totalWs,
-      compliant_workspaces: compliantWs,
-    }
+    return mapSecurityOverviewResults(eventCounts, dayRows, topWorkspaces, flaggedRows, wsCountRows, compliantRows)
   }
 
   async findMandatoryPlugins(orgId: string): Promise<string[]> {
@@ -291,27 +190,5 @@ export class MysqlGuardrailPolicyRepository implements GuardrailPolicyRepository
       [workspaceId],
     )
     return rows.map(r => ({ plugin_id: r.plugin_id }))
-  }
-}
-
-function mapPolicyRow(r: PolicyRow): GuardrailPolicyData {
-  return {
-    id: r.id,
-    org_id: r.org_id,
-    plugin_id: r.plugin_id,
-    enforcement: r.enforcement as GuardrailPolicyData['enforcement'],
-    created_at: r.created_at,
-    updated_at: r.updated_at,
-  }
-}
-
-function mapOverrideRow(r: OverrideRow): GuardrailPolicyOverrideData {
-  return {
-    id: r.id,
-    policy_id: r.policy_id,
-    workspace_id: r.workspace_id,
-    justification: r.justification,
-    created_by: r.created_by,
-    created_at: r.created_at,
   }
 }

--- a/src/infrastructure/persistence/mysql/MysqlWorkspaceRepository.ts
+++ b/src/infrastructure/persistence/mysql/MysqlWorkspaceRepository.ts
@@ -1,5 +1,4 @@
 import type mysql from 'mysql2/promise'
-import type { RowDataPacket } from 'mysql2'
 import type {
   WorkspaceRepository, WorkspaceData, ConnectionData, ConnectionToolData,
   ConsumerData, KnowledgeSourceData, GuardrailData, PermissionData,
@@ -7,24 +6,14 @@ import type {
   WorkspaceRoutingSummary,
 } from '../../../domain/workspace/repository.js'
 import { STATUS_ACTIVE, STATUS_ARCHIVED, STATUS_CONNECTED, STATUS_DISCONNECTED } from '../../../defaults.js'
-
-interface IdRow extends RowDataPacket { id: string }
-interface CountRow extends RowDataPacket { c: number }
-interface TotalRow extends RowDataPacket { total: number }
-interface WsRow extends RowDataPacket, WorkspaceData {}
-interface WsListRow extends RowDataPacket, WorkspaceListItemData {}
-interface ConnRow extends RowDataPacket, ConnectionData {}
-interface ConnConfigRow extends RowDataPacket { name: string; type: string; config: string }
-interface ToolRow extends RowDataPacket, ConnectionToolData {}
-interface ConsumerRow extends RowDataPacket, ConsumerData {}
-interface KnowledgeRow extends RowDataPacket, KnowledgeSourceData {}
-interface GuardrailRow extends RowDataPacket, GuardrailData {}
-interface PermissionRow extends RowDataPacket, PermissionData {}
-interface StatsRow extends RowDataPacket, WorkspaceStatsData {}
-interface ActivityRow extends RowDataPacket, ActivityLogData {}
-interface BoundConsumerRow extends RowDataPacket { workspace_id: string; workspace_name: string }
-interface RoutingSummaryRow extends RowDataPacket { id: string; name: string; system_prompt: string | null; tool_names: string | null }
-interface ConsumersByTypeRow extends RowDataPacket { workspace_id: string; config: string; model: string; system_prompt: string | null; max_tool_rounds: number }
+import {
+  type IdRow, type CountRow, type TotalRow, type WsRow, type WsListRow,
+  type ConnRow, type ConnConfigRow, type ToolRow, type ConsumerRow,
+  type KnowledgeRow, type GuardrailRow, type PermissionRow, type StatsRow,
+  type ActivityRow, type BoundConsumerRow, type RoutingSummaryRow,
+  type ConsumersByTypeRow,
+  mapRoutingSummaryRow,
+} from './WorkspaceRowMappers.js'
 
 export class MysqlWorkspaceRepository implements WorkspaceRepository {
   constructor(private readonly pool: mysql.Pool) {}
@@ -345,12 +334,7 @@ export class MysqlWorkspaceRepository implements WorkspaceRepository {
        GROUP BY w.id`,
       [orgId]
     )
-    return rows.map(r => ({
-      id: r.id,
-      name: r.name,
-      system_prompt: r.system_prompt,
-      tool_names: r.tool_names ? r.tool_names.split(',') : [],
-    }))
+    return rows.map(mapRoutingSummaryRow)
   }
 
   async setDefault(id: string): Promise<void> {

--- a/src/infrastructure/persistence/mysql/WorkspaceRowMappers.ts
+++ b/src/infrastructure/persistence/mysql/WorkspaceRowMappers.ts
@@ -1,0 +1,35 @@
+import type mysql from 'mysql2/promise'
+import type { RowDataPacket } from 'mysql2'
+import type {
+  WorkspaceData, ConnectionData, ConnectionToolData,
+  ConsumerData, KnowledgeSourceData, GuardrailData, PermissionData,
+  WorkspaceStatsData, WorkspaceListItemData, ActivityLogData,
+  WorkspaceRoutingSummary,
+} from '../../../domain/workspace/repository.js'
+
+export interface IdRow extends RowDataPacket { id: string }
+export interface CountRow extends RowDataPacket { c: number }
+export interface TotalRow extends RowDataPacket { total: number }
+export interface WsRow extends RowDataPacket, WorkspaceData {}
+export interface WsListRow extends RowDataPacket, WorkspaceListItemData {}
+export interface ConnRow extends RowDataPacket, ConnectionData {}
+export interface ConnConfigRow extends RowDataPacket { name: string; type: string; config: string }
+export interface ToolRow extends RowDataPacket, ConnectionToolData {}
+export interface ConsumerRow extends RowDataPacket, ConsumerData {}
+export interface KnowledgeRow extends RowDataPacket, KnowledgeSourceData {}
+export interface GuardrailRow extends RowDataPacket, GuardrailData {}
+export interface PermissionRow extends RowDataPacket, PermissionData {}
+export interface StatsRow extends RowDataPacket, WorkspaceStatsData {}
+export interface ActivityRow extends RowDataPacket, ActivityLogData {}
+export interface BoundConsumerRow extends RowDataPacket { workspace_id: string; workspace_name: string }
+export interface RoutingSummaryRow extends RowDataPacket { id: string; name: string; system_prompt: string | null; tool_names: string | null }
+export interface ConsumersByTypeRow extends RowDataPacket { workspace_id: string; config: string; model: string; system_prompt: string | null; max_tool_rounds: number }
+
+export function mapRoutingSummaryRow(row: RoutingSummaryRow): WorkspaceRoutingSummary {
+  return {
+    id: row.id,
+    name: row.name,
+    system_prompt: row.system_prompt,
+    tool_names: row.tool_names ? row.tool_names.split(',') : [],
+  }
+}


### PR DESCRIPTION
## Summary
Two related refactoring changes:

**Row mapper extraction:**
- Extract row interfaces and mapper functions from 3 MySQL repositories into dedicated files
- ConversationRowMappers.ts: 24 row interfaces + 7 mappers
- WorkspaceRowMappers.ts: 17 row interfaces + 1 mapper
- GuardrailPolicyRowMappers.ts: 9 row interfaces + 4 mappers

**Test type safety:**
- Remove 8 `as any` casts across 3 test files
- Add `mockManageConversationUseCase()` and `mockProviderRegistry()` factories to mocks.ts
- RouteMessageUseCase.test.ts: 4 casts removed
- GetModelsUseCase.test.ts: 3 casts removed
- GetHealthUseCase.test.ts: 1 cast removed

All 375 tests pass. Zero TypeScript errors.

## Test plan
- [x] `npx vitest run` passes
- [x] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)