### PR TITLE
refactor: extract GuardrailResolver from container.ts

### DIFF
--- a/src/GuardrailResolver.ts
+++ b/src/GuardrailResolver.ts
@@ -1,0 +1,130 @@
+import { registry as guardrailRegistry, executionCatalogue, retrievalCatalogue, type GuardrailPlugin, ExecutionRailRegistry, RetrievalRailRegistry } from '@supaproxy/guardrails'
+import type { WorkspaceRepository } from './domain/workspace/repository.js'
+import type { MysqlGuardrailPolicyRepository } from './infrastructure/persistence/mysql/MysqlGuardrailPolicyRepository.js'
+import type { MysqlInstalledGuardrailRepository } from './infrastructure/persistence/mysql/MysqlInstalledGuardrailRepository.js'
+import pino from 'pino'
+
+const log = pino({ name: 'guardrail-resolver' })
+
+/**
+ * Resolves guardrail plugins, execution rails, and retrieval rails
+ * for a given workspace based on enabled configs and org policies.
+ */
+export function createGuardrailResolver(deps: {
+  workspaceRepo: WorkspaceRepository
+  guardrailPolicyRepo: MysqlGuardrailPolicyRepository
+  installedGuardrailRepo: MysqlInstalledGuardrailRepository
+}) {
+  const { workspaceRepo, guardrailPolicyRepo, installedGuardrailRepo } = deps
+
+  async function getEnforcedPluginIds(workspaceId: string): Promise<string[]> {
+    const ws = await workspaceRepo.findById(workspaceId)
+    if (!ws?.org_id) return []
+
+    const [mandatory, recommended, overrides] = await Promise.all([
+      guardrailPolicyRepo.findMandatoryPlugins(ws.org_id),
+      guardrailPolicyRepo.findRecommendedPlugins(ws.org_id),
+      guardrailPolicyRepo.findOverridesForWorkspace(workspaceId),
+    ])
+
+    const overriddenPlugins = new Set(overrides.map(o => o.plugin_id))
+    const enforced = [...mandatory]
+    for (const pluginId of recommended) {
+      if (!overriddenPlugins.has(pluginId)) enforced.push(pluginId)
+    }
+    return enforced
+  }
+
+  async function resolveGuardrails(workspaceId: string): Promise<GuardrailPlugin[]> {
+    const configs = await workspaceRepo.findEnabledGuardrailConfigs(workspaceId)
+    const enabledIds = new Set(configs.map(c => c.guardrail_id))
+
+    const enforcedIds = await getEnforcedPluginIds(workspaceId)
+    for (const id of enforcedIds) enabledIds.add(id)
+
+    const plugins: GuardrailPlugin[] = []
+    for (const id of enabledIds) {
+      const factory = guardrailRegistry.has(id) ? () => {
+        const proto = guardrailRegistry.get(id)
+        return new (proto.constructor as new () => GuardrailPlugin)()
+      } : null
+      if (factory) plugins.push(factory())
+    }
+    return plugins
+  }
+
+  async function resolveExecutionRails(workspaceId: string): Promise<ExecutionRailRegistry | null> {
+    const configs = await workspaceRepo.findEnabledGuardrailConfigs(workspaceId)
+    const enabledIds = new Set(configs.map(c => c.guardrail_id))
+    const enforcedIds = await getEnforcedPluginIds(workspaceId)
+    for (const id of enforcedIds) enabledIds.add(id)
+
+    const matchedPlugins = executionCatalogue.list().filter(p => enabledIds.has(p.id))
+    if (matchedPlugins.length === 0) return null
+
+    const reg = new ExecutionRailRegistry()
+    for (const proto of matchedPlugins) {
+      reg.register(new (proto.constructor as new () => typeof proto)())
+    }
+    reg.on((event) => {
+      if (!event.result.allowed) {
+        log.warn({ plugin: event.pluginId, tool: event.ctx.toolName, workspace: event.ctx.workspaceId, reason: event.result.reason }, 'Tool call blocked by execution rail')
+      }
+    })
+    return reg
+  }
+
+  async function resolveRetrievalRails(workspaceId: string): Promise<RetrievalRailRegistry | null> {
+    const configs = await workspaceRepo.findEnabledGuardrailConfigs(workspaceId)
+    const enabledIds = new Set(configs.map(c => c.guardrail_id))
+    const enforcedIds = await getEnforcedPluginIds(workspaceId)
+    for (const id of enforcedIds) enabledIds.add(id)
+
+    const matchedPlugins = retrievalCatalogue.list().filter(p => enabledIds.has(p.id))
+    if (matchedPlugins.length === 0) return null
+
+    const reg = new RetrievalRailRegistry()
+    for (const proto of matchedPlugins) {
+      reg.register(new (proto.constructor as new () => typeof proto)())
+    }
+    reg.on((event) => {
+      log.warn({ plugin: event.pluginId, stripped: event.result.stripped }, 'Injection attempt detected in tool output')
+    })
+    return reg
+  }
+
+  const corePluginIds = new Set([
+    ...guardrailRegistry.list().map(p => p.id),
+    ...executionCatalogue.list().map(p => p.id),
+    ...retrievalCatalogue.list().map(p => p.id),
+  ])
+
+  type GuardrailInfo = { id: string; name: string; description: string; stage: string; source: 'core' | 'marketplace'; icon?: string; configSchema: { fields: Array<{ name: string; label: string; type: string; required?: boolean; placeholder?: string; helpText?: string; options?: Array<{ value: string; label: string }>; defaultValue?: string | boolean | number }> } }
+
+  async function listAvailableGuardrails(orgId: string): Promise<GuardrailInfo[]> {
+    const toCore = (p: { id: string; name: string; description: string; stage: string; icon?: string; configSchema: GuardrailInfo['configSchema'] }): GuardrailInfo => ({
+      id: p.id, name: p.name, description: p.description, stage: p.stage, source: 'core', icon: p.icon, configSchema: p.configSchema,
+    })
+
+    const core: GuardrailInfo[] = [
+      ...guardrailRegistry.list().map(toCore),
+      ...executionCatalogue.list().map(toCore),
+      ...retrievalCatalogue.list().map(toCore),
+    ]
+
+    const installed = await installedGuardrailRepo.findByOrg(orgId)
+    const marketplace: GuardrailInfo[] = installed.map(ig => ({
+      id: ig.plugin_id,
+      name: ig.plugin_metadata.name,
+      description: ig.plugin_metadata.description,
+      stage: ig.plugin_metadata.stage,
+      source: 'marketplace' as const,
+      icon: ig.plugin_metadata.icon,
+      configSchema: ig.plugin_metadata.configSchema,
+    }))
+
+    return [...core, ...marketplace]
+  }
+
+  return { resolveGuardrails, resolveExecutionRails, resolveRetrievalRails, listAvailableGuardrails, corePluginIds }
+}

--- a/src/container.ts
+++ b/src/container.ts
@@ -10,7 +10,7 @@ import { MysqlModelRepository } from './infrastructure/persistence/mysql/MysqlMo
 import { BcryptPasswordService } from './infrastructure/auth/BcryptPasswordService.js'
 import { JwtTokenService } from './infrastructure/auth/JwtTokenService.js'
 import { registry as providerRegistry } from '@supaproxy/providers'
-import { registry as guardrailRegistry, executionCatalogue, retrievalCatalogue, type GuardrailPlugin, ExecutionRailRegistry, RetrievalRailRegistry } from '@supaproxy/guardrails'
+import { createGuardrailResolver } from './GuardrailResolver.js'
 import { McpClientFactoryImpl } from './infrastructure/mcp/McpClientFactoryImpl.js'
 import { BullMqService } from './infrastructure/queue/BullMqService.js'
 import { ConsumerIntegrationTester } from './infrastructure/auth/ConsumerIntegrationTester.js'
@@ -247,124 +247,11 @@ export function createContainer(pool: mysql.Pool, options?: { tenantService?: Te
   const connectConsumerUseCase = new ConnectConsumerUseCase(workspaceRepo, consumerTypeHandlers)
 
   // Guardrails: resolved per workspace at query time from package catalogues.
-  // The server never imports concrete plugin classes. It discovers them
-  // from the registries that plugins populate at import time.
-
-  async function resolveGuardrails(workspaceId: string): Promise<GuardrailPlugin[]> {
-    const configs = await workspaceRepo.findEnabledGuardrailConfigs(workspaceId)
-    const enabledIds = new Set(configs.map(c => c.guardrail_id))
-
-    const enforcedIds = await getEnforcedPluginIds(workspaceId)
-    for (const id of enforcedIds) enabledIds.add(id)
-
-    const plugins: GuardrailPlugin[] = []
-    for (const id of enabledIds) {
-      const factory = guardrailRegistry.has(id) ? () => {
-        // Create a fresh instance from the registered prototype's constructor
-        const proto = guardrailRegistry.get(id)
-        return new (proto.constructor as new () => GuardrailPlugin)()
-      } : null
-      if (factory) plugins.push(factory())
-    }
-    return plugins
-  }
-
-  async function getEnforcedPluginIds(workspaceId: string): Promise<string[]> {
-    const ws = await workspaceRepo.findById(workspaceId)
-    if (!ws?.org_id) return []
-
-    const [mandatory, recommended, overrides] = await Promise.all([
-      guardrailPolicyRepo.findMandatoryPlugins(ws.org_id),
-      guardrailPolicyRepo.findRecommendedPlugins(ws.org_id),
-      guardrailPolicyRepo.findOverridesForWorkspace(workspaceId),
-    ])
-
-    const overriddenPlugins = new Set(overrides.map(o => o.plugin_id))
-    const enforced = [...mandatory]
-    for (const pluginId of recommended) {
-      if (!overriddenPlugins.has(pluginId)) enforced.push(pluginId)
-    }
-    return enforced
-  }
-
-  // Core plugin IDs: derived from catalogues, never hardcoded
-  const corePluginIds = new Set([
-    ...guardrailRegistry.list().map(p => p.id),
-    ...executionCatalogue.list().map(p => p.id),
-    ...retrievalCatalogue.list().map(p => p.id),
-  ])
-
-  // List all available guardrails: core (from catalogues) + installed (from DB)
-  async function listAvailableGuardrails(orgId: string) {
-    type Info = { id: string; name: string; description: string; stage: string; source: 'core' | 'marketplace'; icon?: string; configSchema: { fields: Array<{ name: string; label: string; type: string; required?: boolean; placeholder?: string; helpText?: string; options?: Array<{ value: string; label: string }>; defaultValue?: string | boolean | number }> } }
-    const toCore = (p: { id: string; name: string; description: string; stage: string; icon?: string; configSchema: Info['configSchema'] }): Info => ({
-      id: p.id, name: p.name, description: p.description, stage: p.stage, source: 'core', icon: p.icon, configSchema: p.configSchema,
-    })
-
-    const core: Info[] = [
-      ...guardrailRegistry.list().map(toCore),
-      ...executionCatalogue.list().map(toCore),
-      ...retrievalCatalogue.list().map(toCore),
-    ]
-
-    const installed = await installedGuardrailRepo.findByOrg(orgId)
-    const marketplace: Info[] = installed.map(ig => ({
-      id: ig.plugin_id,
-      name: ig.plugin_metadata.name,
-      description: ig.plugin_metadata.description,
-      stage: ig.plugin_metadata.stage,
-      source: 'marketplace' as const,
-      icon: ig.plugin_metadata.icon,
-      configSchema: ig.plugin_metadata.configSchema,
-    }))
-
-    return [...core, ...marketplace]
-  }
+  const guardrails = createGuardrailResolver({ workspaceRepo, guardrailPolicyRepo, installedGuardrailRepo })
+  const { resolveGuardrails, resolveExecutionRails, resolveRetrievalRails, listAvailableGuardrails, corePluginIds } = guardrails
 
   const promptTemplateRepo = new MysqlPromptTemplateRepository(pool)
   const promptResolver = new PromptResolver(promptTemplateRepo)
-
-  // Execution and retrieval rails: resolved per workspace from catalogues + org policies
-  async function resolveExecutionRails(workspaceId: string): Promise<ExecutionRailRegistry | null> {
-    const configs = await workspaceRepo.findEnabledGuardrailConfigs(workspaceId)
-    const enabledIds = new Set(configs.map(c => c.guardrail_id))
-    const enforcedIds = await getEnforcedPluginIds(workspaceId)
-    for (const id of enforcedIds) enabledIds.add(id)
-
-    // Find which execution rail plugins are enabled for this workspace
-    const matchedPlugins = executionCatalogue.list().filter(p => enabledIds.has(p.id))
-    if (matchedPlugins.length === 0) return null
-
-    const reg = new ExecutionRailRegistry()
-    for (const proto of matchedPlugins) {
-      reg.register(new (proto.constructor as new () => typeof proto)())
-    }
-    reg.on((event) => {
-      if (!event.result.allowed) {
-        log.warn({ plugin: event.pluginId, tool: event.ctx.toolName, workspace: event.ctx.workspaceId, reason: event.result.reason }, 'Tool call blocked by execution rail')
-      }
-    })
-    return reg
-  }
-
-  async function resolveRetrievalRails(workspaceId: string): Promise<RetrievalRailRegistry | null> {
-    const configs = await workspaceRepo.findEnabledGuardrailConfigs(workspaceId)
-    const enabledIds = new Set(configs.map(c => c.guardrail_id))
-    const enforcedIds = await getEnforcedPluginIds(workspaceId)
-    for (const id of enforcedIds) enabledIds.add(id)
-
-    const matchedPlugins = retrievalCatalogue.list().filter(p => enabledIds.has(p.id))
-    if (matchedPlugins.length === 0) return null
-
-    const reg = new RetrievalRailRegistry()
-    for (const proto of matchedPlugins) {
-      reg.register(new (proto.constructor as new () => typeof proto)())
-    }
-    reg.on((event) => {
-      log.warn({ plugin: event.pluginId, stripped: event.result.stripped }, 'Injection attempt detected in tool output')
-    })
-    return reg
-  }
 
   const guardrailEventRepo = new MysqlGuardrailEventRepository(pool)
   const preQueryGuardDeps = new PreQueryGuardDepsImpl(pool, REDIS_HOST, REDIS_PORT)


### PR DESCRIPTION
## Summary
Extract ~120 lines of guardrail resolution logic from container.ts into GuardrailResolver.ts:
- resolveGuardrails, resolveExecutionRails, resolveRetrievalRails
- listAvailableGuardrails, corePluginIds
- getEnforcedPluginIds (policy enforcement helper)

container.ts: 429 → 317 lines. Remaining content is imports and composition root wiring.

All 375 tests pass.

## Test plan
- [x] `npx vitest run` passes
- [x] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)