### PR TITLE
chore: gitignore .pnpmfile.cjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ var/
 _git/
 OSS_ROADMAP.md
 DEV.md
+.pnpmfile.cjs
 apps/web/


### PR DESCRIPTION
Allow local package linking via pnpmfile hook without polluting package.json. Docker builds use published versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)