### PR TITLE
chore: release @supaproxy/core v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.0.0] - 2026-05-20
+
+### Added
+- `DatabaseAdapter` interface for pluggable database backends
+- `createContainer(infra, options)` accepts injected `DatabaseAdapter`
+- Exported domain interfaces for all 11 repositories
+- Exported application ports (ModelRepository, DatabaseAdapter)
+- Exported defaults (status constants, pagination limits)
+- `validateDatabaseAdapter()` test helper for adapter authors
+- Composable server architecture: core + auth + database adapters
+
+### Changed
+- MySQL implementations extracted to `@supaproxy/mysql` package
+- Auth extracted to `@supaproxy/auth` package
+- Container no longer hardcodes database or auth implementations
+- Migrations moved to database adapter packages
+
+### Removed
+- `src/infrastructure/persistence/mysql/` (moved to `@supaproxy/mysql`)
+- `src/db/migrations.ts`, `src/db/types.ts`, `src/db/seed.ts` (moved to `@supaproxy/mysql`)
+
 ## [0.1.0] - 2026-04-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -67,6 +67,12 @@
     "typescript": "^5.8.0",
     "vitest": "^3.1.0"
   },
+  "files": [
+    "src"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "packageManager": "pnpm@9.15.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add publishConfig, files field, and CHANGELOG for first npm publish.