### PR TITLE
fix: regenerate lockfile for CI

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,20 +30,20 @@ dependencies:
     specifier: ^1.0.0
     version: 1.0.0(hono@4.12.14)
   '@supaproxy/connections':
-    specifier: link:/Users/Elvis/workspace/supaproxyhq/supaproxy-connections
-    version: link:../supaproxy-connections
+    specifier: ^0.2.1
+    version: 0.2.1(zod@3.25.76)
   '@supaproxy/consumers':
-    specifier: link:/Users/Elvis/workspace/supaproxyhq/supaproxy-consumers
-    version: link:../supaproxy-consumers
+    specifier: ^0.4.1
+    version: 0.4.1(@slack/bolt@4.7.0)
   '@supaproxy/guardrails':
-    specifier: link:/Users/Elvis/workspace/supaproxyhq/supaproxy-guardrails
-    version: link:../supaproxy-guardrails
+    specifier: ^0.7.5
+    version: 0.7.5
   '@supaproxy/mysql':
     specifier: ^1.0.0
     version: 1.0.0(@types/node@22.19.17)
   '@supaproxy/providers':
-    specifier: link:/Users/Elvis/workspace/supaproxyhq/supaproxy-providers
-    version: link:../supaproxy-providers
+    specifier: ^0.2.3
+    version: 0.2.3(@anthropic-ai/sdk@0.90.0)(openai@6.35.0)
   apache-arrow:
     specifier: ^18.1.0
     version: 18.1.0
@@ -985,6 +985,33 @@ packages:
       pino: 9.14.0
     dev: false
 
+  /@supaproxy/connections@0.2.1(zod@3.25.76):
+    resolution: {integrity: sha512-+DUT/4Lk0NDp6F8aaiouM/D72tT/giFaVz1aWRYw+FU/kGnXbJrgC99ycnoB0N2+mo1YPyxzoBNVs5vcKq5wjQ==}
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      pino: 9.14.0
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+      - zod
+    dev: false
+
+  /@supaproxy/consumers@0.4.1(@slack/bolt@4.7.0):
+    resolution: {integrity: sha512-NBuxHM66w6u/ZfDJh+vBflglD9H5YNXN7DnJLmw/ioMsjpRiNqq1A0OED0ePynRsWUfGsHOXTrCq9/XVxNItgw==}
+    peerDependencies:
+      '@slack/bolt': ^4.0.0
+    peerDependenciesMeta:
+      '@slack/bolt':
+        optional: true
+    dependencies:
+      '@slack/bolt': 4.7.0
+      pino: 9.14.0
+    dev: false
+
+  /@supaproxy/guardrails@0.7.5:
+    resolution: {integrity: sha512-YI/wwqbmFIiUw2lyzMmoFFDLKcCBSmAiyzJdVd3PnkHrg6ksGGuAFDAPBNzzTUBc3nWfYIJWK0O8EyDF+bjXXA==}
+    dev: false
+
   /@supaproxy/mysql@1.0.0(@types/node@22.19.17):
     resolution: {integrity: sha512-7WXGb9XnP4nsahI52vxIVaztJHN0ptk2yvVhHluwhBNGXKokQbfu4TiPS7DM31fbAbMQBITrPA8ySIMFC2V/fQ==}
     peerDependencies:
@@ -994,6 +1021,22 @@ packages:
       pino: 9.14.0
     transitivePeerDependencies:
       - '@types/node'
+    dev: false
+
+  /@supaproxy/providers@0.2.3(@anthropic-ai/sdk@0.90.0)(openai@6.35.0):
+    resolution: {integrity: sha512-j6j2cHV5wSz5OhuRgmhVGyzm8gKUI6+0hI+W1KC2/IYetfNRfNpSX+KnHnRO4HW7eUkVCBayne9WMIPVJQqQeQ==}
+    peerDependencies:
+      '@anthropic-ai/sdk': '>=0.30.0'
+      openai: '>=4.0.0'
+    peerDependenciesMeta:
+      '@anthropic-ai/sdk':
+        optional: true
+      openai:
+        optional: true
+    dependencies:
+      '@anthropic-ai/sdk': 0.90.0(zod@3.25.76)
+      openai: 6.35.0(zod@3.25.76)
+      pino: 9.14.0
     dev: false
 
   /@swc/helpers@0.5.21:


### PR DESCRIPTION
## Summary

CI was failing because the lockfile had local `link:` paths from `.pnpmfile.cjs` dev overrides. The lockfile showed `@supaproxy/connections: link:/Users/Elvis/...` but package.json has `^0.2.1`. CI's `--frozen-lockfile` rightly rejected the mismatch.

Regenerated the lockfile with `.pnpmfile.cjs` temporarily disabled so all deps resolve from npm.

## Root cause

`.pnpmfile.cjs` (gitignored) overrides `@supaproxy/*` deps to local links for development. When `pnpm install` runs locally, it writes these link paths into the lockfile. The lockfile gets committed, but CI doesn't have the local directories.

## Test plan

- [x] All 369 tests pass
- [x] `pnpm lint` passes
- [ ] CI passes with `--frozen-lockfile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)