### PR TITLE
fix: address audit findings

### DIFF
--- a/src/GuardrailResolver.ts
+++ b/src/GuardrailResolver.ts
@@ -2,6 +2,7 @@ import { type GuardrailPlugin, ExecutionRailRegistry, RetrievalRailRegistry } fr
 import type { WorkspaceRepository } from './domain/workspace/repository.js'
 import type { GuardrailPolicyRepository } from './domain/guardrail/policyRepository.js'
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- registry holds heterogeneous plugin types
 export interface PluginRegistry<T = any> {
   list(): T[]
   has(id: string): boolean

--- a/src/application/connector/SaveMcpConnectionUseCase.ts
+++ b/src/application/connector/SaveMcpConnectionUseCase.ts
@@ -2,6 +2,7 @@ import type { WorkspaceRepository } from '../../domain/workspace/repository.js'
 import type { McpClientFactory } from '../ports/McpClient.js'
 import { generateId } from '../../domain/shared/EntityId.js'
 import { NotFoundError, ValidationError } from '../../domain/shared/errors.js'
+import { STATUS_CONNECTED, STATUS_SAVED } from '../../defaults.js'
 
 interface SaveMcpInput {
   workspaceId: string
@@ -59,7 +60,7 @@ export class SaveMcpConnectionUseCase {
       return this.discoverAndSaveTools(connId, input.url, input.headers)
     }
 
-    return { status: 'saved', message: 'Connection saved. Tools will be discovered on the first query.' }
+    return { status: STATUS_SAVED, message: 'Connection saved. Tools will be discovered on the first query.' }
   }
 
   private async discoverAndSaveTools(connId: string, url: string, headers?: Record<string, string>): Promise<SaveMcpOutput> {
@@ -78,13 +79,13 @@ export class SaveMcpConnectionUseCase {
             }))
           )
         }
-        await this.workspaceRepo.updateConnectionStatus(connId, 'connected')
-        return { status: 'saved', message: `Connected, ${connection.tools.length} tools discovered.`, tools: connection.tools.length }
+        await this.workspaceRepo.updateConnectionStatus(connId, STATUS_CONNECTED)
+        return { status: STATUS_SAVED, message: `Connected, ${connection.tools.length} tools discovered.`, tools: connection.tools.length }
       } finally {
         await connection.close()
       }
     } catch (err) {
-      return { status: 'saved', message: `Saved but could not discover tools: ${(err as Error).message}`, tools: 0 }
+      return { status: STATUS_SAVED, message: `Saved but could not discover tools: ${(err as Error).message}`, tools: 0 }
     }
   }
 }

--- a/src/application/conversation/CloseConversationUseCase.ts
+++ b/src/application/conversation/CloseConversationUseCase.ts
@@ -2,6 +2,7 @@ import type { ConversationRepository } from '../../domain/conversation/repositor
 import type { QueueService } from '../ports/QueueService.js'
 import { generateId } from '../../domain/shared/EntityId.js'
 import { NotFoundError } from '../../domain/shared/errors.js'
+import { STATUS_CLOSED, STATUS_COMPLETE, STATUS_PENDING } from '../../defaults.js'
 
 export class CloseConversationUseCase {
   constructor(
@@ -13,14 +14,14 @@ export class CloseConversationUseCase {
     const conversation = await this.conversationRepo.findById(conversationId)
     if (!conversation) throw new NotFoundError('Conversation', conversationId)
 
-    if (conversation.status !== 'closed') {
+    if (conversation.status !== STATUS_CLOSED) {
       await this.conversationRepo.closeConversation(conversationId)
     }
 
     const existingStats = await this.conversationRepo.findStats(conversationId)
     if (existingStats) {
-      if (existingStats.stats_status !== 'complete') {
-        await this.conversationRepo.updateStatsStatus(existingStats.id, 'pending')
+      if (existingStats.stats_status !== STATUS_COMPLETE) {
+        await this.conversationRepo.updateStatsStatus(existingStats.id, STATUS_PENDING)
       }
     } else {
       await this.conversationRepo.createStats(generateId(), conversationId)

--- a/src/application/conversation/ManageConversationUseCase.ts
+++ b/src/application/conversation/ManageConversationUseCase.ts
@@ -1,5 +1,6 @@
 import type { ConversationRepository } from '../../domain/conversation/repository.js'
 import { generateId } from '../../domain/shared/EntityId.js'
+import { STATUS_OPEN, STATUS_COLD } from '../../defaults.js'
 
 export class ManageConversationUseCase {
   constructor(private readonly conversationRepo: ConversationRepository) {}
@@ -8,8 +9,8 @@ export class ManageConversationUseCase {
     const existing = await this.conversationRepo.findLatestByThread(workspaceId, consumerType, externalThreadId)
 
     if (existing) {
-      if (existing.status === 'open' || existing.status === 'cold') {
-        if (existing.status === 'cold') {
+      if (existing.status === STATUS_OPEN || existing.status === STATUS_COLD) {
+        if (existing.status === STATUS_COLD) {
           await this.conversationRepo.reopenFromCold(existing.id)
         }
         return existing.id

--- a/src/application/integration/ManageIntegrationUseCase.ts
+++ b/src/application/integration/ManageIntegrationUseCase.ts
@@ -1,5 +1,6 @@
 import type { IntegrationRepository } from '../../domain/integration/repository.js'
 import { generateId } from '../../domain/shared/EntityId.js'
+import { STATUS_ACTIVE } from '../../defaults.js'
 
 export class ManageIntegrationUseCase {
   constructor(private readonly integrationRepo: IntegrationRepository) {}
@@ -11,9 +12,9 @@ export class ManageIntegrationUseCase {
   async activate(orgId: string, type: string): Promise<void> {
     const existing = await this.integrationRepo.findByOrgAndType(orgId, type)
 
-    if (existing && existing.status === 'active') return
+    if (existing && existing.status === STATUS_ACTIVE) return
     if (existing && existing.status === 'inactive') {
-      await this.integrationRepo.updateStatus(existing.id, 'active')
+      await this.integrationRepo.updateStatus(existing.id, STATUS_ACTIVE)
       return
     }
 
@@ -21,7 +22,7 @@ export class ManageIntegrationUseCase {
       id: generateId(),
       org_id: orgId,
       type,
-      status: 'active',
+      status: STATUS_ACTIVE,
     })
   }
 

--- a/src/application/prompt/injection-patterns.ts
+++ b/src/application/prompt/injection-patterns.ts
@@ -117,7 +117,7 @@ export function decodeBase64Segments(text: string): string[] {
       if (/^[\x20-\x7E\s]+$/.test(decoded) && decoded.length > 5) {
         segments.push(decoded)
       }
-    } catch { /* not valid base64 */ }
+    } catch { /* not valid base64, expected for non-base64 matches */ }
   }
   return segments
 }

--- a/src/application/query/ExecuteQueryUseCase.ts
+++ b/src/application/query/ExecuteQueryUseCase.ts
@@ -83,7 +83,8 @@ export class ExecuteQueryUseCase {
       const resolved = await this.resolveProvider(workspace.provider_type)
       provider = resolved.provider
       apiKey = resolved.apiKey
-    } catch {
+    } catch (err) {
+      log.warn({ error: (err as Error).message }, 'Failed to resolve AI provider')
       return buildQueryResult({
         answer: ERROR_CODES.NO_AI_PROVIDER,
         error: ERROR_CODES.NO_AI_PROVIDER,
@@ -230,7 +231,7 @@ export class ExecuteQueryUseCase {
       }
     } finally {
       for (const conn of mcpConnections) {
-        try { await conn.close() } catch { /* ignore */ }
+        try { await conn.close() } catch (err) { log.warn({ error: (err as Error).message }, 'Failed to close MCP connection') }
       }
     }
   }

--- a/src/application/query/ToolCallProcessor.ts
+++ b/src/application/query/ToolCallProcessor.ts
@@ -2,6 +2,7 @@ import type { AIContentBlock, AIToolSpec } from '@supaproxy/providers'
 import type { ExecutionRailRegistry, RetrievalRailRegistry } from '@supaproxy/guardrails'
 import type { GuardrailEventRepository, GuardrailEventData } from '../../domain/guardrail/repository.js'
 import { generateId } from '../../domain/shared/EntityId.js'
+import { STATUS_OPEN } from '../../defaults.js'
 import pino from 'pino'
 
 const log = pino({ name: 'tool-call-processor' })
@@ -74,7 +75,7 @@ export class ToolCallProcessor {
             outcome: { reason: railResult.reason || null },
             display: plugin?.eventDisplay || [],
             actions: plugin?.eventActions || [],
-            status: 'open',
+            status: STATUS_OPEN,
           })
           continue
         }
@@ -99,7 +100,7 @@ export class ToolCallProcessor {
               outcome: { original_content: resultText.substring(0, 1000), stripped_content: sanitised.stripped.join(', ').substring(0, 500) },
               display: plugin?.eventDisplay || [],
               actions: plugin?.eventActions || [],
-              status: 'open',
+              status: STATUS_OPEN,
             })
           }
           resultText = sanitised.content

--- a/src/application/workspace/CreateWorkspaceUseCase.ts
+++ b/src/application/workspace/CreateWorkspaceUseCase.ts
@@ -1,7 +1,7 @@
 import type { OrganisationRepository } from '../../domain/organisation/repository.js'
 import type { WorkspaceRepository } from '../../domain/workspace/repository.js'
 import { generateId, generateWorkspaceId } from '../../domain/shared/EntityId.js'
-import { DEFAULT_SYSTEM_PROMPT } from '../../defaults.js'
+import { DEFAULT_SYSTEM_PROMPT, STATUS_ACTIVE } from '../../defaults.js'
 
 interface CreateWorkspaceInput {
   name: string
@@ -31,7 +31,7 @@ export class CreateWorkspaceUseCase {
       systemPrompt: input.systemPrompt || DEFAULT_SYSTEM_PROMPT,
     })
 
-    return { id: wsId, name: input.name, status: 'active' }
+    return { id: wsId, name: input.name, status: STATUS_ACTIVE }
   }
 
   private async resolveTeam(orgId: string, teamId?: string, teamName?: string): Promise<string | null> {

--- a/src/application/workspace/GetHealthUseCase.ts
+++ b/src/application/workspace/GetHealthUseCase.ts
@@ -25,7 +25,7 @@ export class GetHealthUseCase {
 
   async executeAuthenticated(): Promise<HealthOutput> {
     // Check all registered provider types for API keys
-    const providerTypes = this.providerRegistry?.types() || ['anthropic', 'openai']
+    const providerTypes = this.providerRegistry?.types() || []
     let aiConfigured = false
     let embeddingAvailable = false
 

--- a/src/container.ts
+++ b/src/container.ts
@@ -100,8 +100,8 @@ import { createGuardrailPolicyRoutes } from './presentation/routes/guardrailPoli
 interface ContainerOptions {
   pool: import('mysql2/promise').Pool
   tenantService?: TenantService
-  authRoutes: Hono
-  requireAuth: (c: any, next: any) => Promise<any>
+  authRoutes: Hono<Record<string, unknown>>
+  requireAuth: (c: unknown, next: () => Promise<void>) => Promise<Response | void>
   guardrailRegistry: PluginRegistry
   executionCatalogue: PluginRegistry
   retrievalCatalogue: PluginRegistry

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,8 @@
  * Uses the composable pieces directly. No cloud overlay.
  * Single-tenant mode (NoOpTenantService is the default).
  *
- * The cloud overlay (supaproxy-cloud) imports from ./server.ts
- * and injects CloudTenantService + additional routes.
+ * Cloud overlays import from ./server.ts and inject their own
+ * TenantService + additional routes.
  */
 import 'dotenv/config'
 import { serve } from '@hono/node-server'
@@ -57,7 +57,7 @@ const { routes: authRoutes, requireAuth } = createAuthRoutes({
 })
 
 // --- Composition root ---
-const container = createContainer(infra, { pool, authRoutes: authRoutes as any, requireAuth, guardrailRegistry, executionCatalogue, retrievalCatalogue })
+const container = createContainer(infra, { pool, authRoutes, requireAuth, guardrailRegistry, executionCatalogue, retrievalCatalogue })
 
 // --- App ---
 const app = createApp(container)

--- a/src/infrastructure/guard/PreQueryGuardDepsImpl.ts
+++ b/src/infrastructure/guard/PreQueryGuardDepsImpl.ts
@@ -23,7 +23,7 @@ export class PreQueryGuardDepsImpl implements PreQueryGuardDeps {
   ) {
     if (redisHost && redisPort) {
       this.redis = new Redis({ host: redisHost, port: redisPort, maxRetriesPerRequest: 1, lazyConnect: true })
-      this.redis.connect().catch(() => { this.redis = null })
+      this.redis.connect().catch((err) => { log.warn({ error: (err as Error).message }, 'Redis connection failed, rate limiting disabled'); this.redis = null })
     }
   }
 
@@ -52,7 +52,7 @@ export class PreQueryGuardDepsImpl implements PreQueryGuardDeps {
         if (cfg.cost_cap_monthly_usd != null) merged.cost_cap_monthly_usd = cfg.cost_cap_monthly_usd
         if (cfg.rate_limit) merged.rate_limit = { ...merged.rate_limit, ...cfg.rate_limit }
         if (cfg.blocked_topics) merged.blocked_topics = [...(merged.blocked_topics || []), ...cfg.blocked_topics]
-      } catch { /* skip invalid JSON */ }
+      } catch (err) { log.warn({ error: (err as Error).message }, 'Invalid guardrail config JSON, skipping') }
     }
     return Object.keys(merged).length > 0 ? merged : null
   }

--- a/src/presentation/routes/conversations.ts
+++ b/src/presentation/routes/conversations.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import pino from 'pino'
+import { STATUS_CLOSED } from '../../defaults.js'
 import type { ListConversationsUseCase } from '../../application/conversation/ListConversationsUseCase.js'
 import type { GetConversationDetailUseCase } from '../../application/conversation/GetConversationDetailUseCase.js'
 import type { CloseConversationUseCase } from '../../application/conversation/CloseConversationUseCase.js'
@@ -65,7 +66,7 @@ export function createConversationRoutes(deps: ConversationRouteDeps) {
     try {
       await deps.closeConversationUseCase.execute(c.req.param('cid'))
       log.info({ conversationId: c.req.param('cid') }, 'Conversation closed manually, analysis queued')
-      return c.json({ status: 'closed', message: 'closed' })
+      return c.json({ status: STATUS_CLOSED, message: STATUS_CLOSED })
     } catch (err) {
       if (err instanceof NotFoundError) return c.json({ error: 'not_found' }, 404)
       throw err


### PR DESCRIPTION
## Summary

Fixes from the 2026-05-20 ecosystem audit.

**Hardcoded status strings (9 locations):**
- ManageIntegrationUseCase, CreateWorkspaceUseCase, SaveMcpConnectionUseCase,
  CloseConversationUseCase, ManageConversationUseCase, ToolCallProcessor,
  conversations route — all now use STATUS_* constants from defaults.ts

**Empty catch blocks (5 violations):**
- PreQueryGuardDepsImpl: Redis connect and JSON parse now log warnings
- ExecuteQueryUseCase: provider resolve and MCP close now log warnings
- injection-patterns: documented intent for base64 catch

**Type safety (3 violations):**
- container.ts: `requireAuth` parameter typed properly instead of `any`
- index.ts: removed `as any` cast on authRoutes
- GuardrailResolver: documented PluginRegistry generic default

**Provider agnosticism:**
- GetHealthUseCase: removed hardcoded `['anthropic', 'openai']` fallback

**Security:**
- Removed private repo name reference from public source comment

## Test plan

- [x] All 369 tests pass
- [x] Type-checks cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)