### PR TITLE
test: add tests for 3 zero-coverage infrastructure files

### DIFF
--- a/src/infrastructure/guard/PreQueryGuardDepsImpl.test.ts
+++ b/src/infrastructure/guard/PreQueryGuardDepsImpl.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock ioredis before importing the class under test
+const mockIncr = vi.fn()
+const mockExpire = vi.fn()
+const mockConnect = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('ioredis', () => {
+  return {
+    default: vi.fn().mockImplementation(() => ({
+      incr: mockIncr,
+      expire: mockExpire,
+      connect: mockConnect,
+    })),
+  }
+})
+
+// Mock pino to silence logs
+vi.mock('pino', () => ({
+  default: () => ({
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+  }),
+}))
+
+import { PreQueryGuardDepsImpl } from './PreQueryGuardDepsImpl.js'
+
+function mockPool() {
+  return {
+    execute: vi.fn(),
+  } as any
+}
+
+describe('PreQueryGuardDepsImpl', () => {
+  let pool: ReturnType<typeof mockPool>
+
+  beforeEach(() => {
+    pool = mockPool()
+    vi.clearAllMocks()
+  })
+
+  describe('getMonthlySpend', () => {
+    it('returns the total from the query result', async () => {
+      pool.execute.mockResolvedValue([[{ total: 42.5 }]])
+      const deps = new PreQueryGuardDepsImpl(pool)
+
+      const result = await deps.getMonthlySpend('ws-1')
+
+      expect(result).toBe(42.5)
+      expect(pool.execute).toHaveBeenCalledWith(
+        expect.stringContaining('SUM(cost_usd)'),
+        ['ws-1'],
+      )
+    })
+
+    it('returns 0 when total is null', async () => {
+      pool.execute.mockResolvedValue([[{ total: null }]])
+      const deps = new PreQueryGuardDepsImpl(pool)
+
+      const result = await deps.getMonthlySpend('ws-1')
+
+      expect(result).toBe(0)
+    })
+
+    it('returns 0 when rows are empty', async () => {
+      pool.execute.mockResolvedValue([[]])
+      const deps = new PreQueryGuardDepsImpl(pool)
+
+      const result = await deps.getMonthlySpend('ws-1')
+
+      expect(result).toBe(0)
+    })
+  })
+
+  describe('getWorkspaceGuardrailConfig', () => {
+    it('returns null when no guardrail rows exist', async () => {
+      pool.execute.mockResolvedValue([[]])
+      const deps = new PreQueryGuardDepsImpl(pool)
+
+      const result = await deps.getWorkspaceGuardrailConfig('ws-1')
+
+      expect(result).toBeNull()
+    })
+
+    it('merges cost_cap from a single config row', async () => {
+      pool.execute.mockResolvedValue([[
+        { config: JSON.stringify({ cost_cap_monthly_usd: 100 }) },
+      ]])
+      const deps = new PreQueryGuardDepsImpl(pool)
+
+      const result = await deps.getWorkspaceGuardrailConfig('ws-1')
+
+      expect(result).toEqual({ cost_cap_monthly_usd: 100 })
+    })
+
+    it('merges multiple config rows', async () => {
+      pool.execute.mockResolvedValue([[
+        { config: JSON.stringify({ cost_cap_monthly_usd: 200 }) },
+        { config: JSON.stringify({ rate_limit: { per_user_per_minute: 10 } }) },
+        { config: JSON.stringify({ blocked_topics: ['pii'] }) },
+      ]])
+      const deps = new PreQueryGuardDepsImpl(pool)
+
+      const result = await deps.getWorkspaceGuardrailConfig('ws-1')
+
+      expect(result).toEqual({
+        cost_cap_monthly_usd: 200,
+        rate_limit: { per_user_per_minute: 10 },
+        blocked_topics: ['pii'],
+      })
+    })
+
+    it('concatenates blocked_topics from multiple rows', async () => {
+      pool.execute.mockResolvedValue([[
+        { config: JSON.stringify({ blocked_topics: ['pii'] }) },
+        { config: JSON.stringify({ blocked_topics: ['violence', 'hate'] }) },
+      ]])
+      const deps = new PreQueryGuardDepsImpl(pool)
+
+      const result = await deps.getWorkspaceGuardrailConfig('ws-1')
+
+      expect(result?.blocked_topics).toEqual(['pii', 'violence', 'hate'])
+    })
+
+    it('skips rows with null config', async () => {
+      pool.execute.mockResolvedValue([[
+        { config: null },
+        { config: JSON.stringify({ cost_cap_monthly_usd: 50 }) },
+      ]])
+      const deps = new PreQueryGuardDepsImpl(pool)
+
+      const result = await deps.getWorkspaceGuardrailConfig('ws-1')
+
+      expect(result).toEqual({ cost_cap_monthly_usd: 50 })
+    })
+
+    it('skips rows with invalid JSON and merges the rest', async () => {
+      pool.execute.mockResolvedValue([[
+        { config: 'NOT VALID JSON' },
+        { config: JSON.stringify({ cost_cap_monthly_usd: 75 }) },
+      ]])
+      const deps = new PreQueryGuardDepsImpl(pool)
+
+      const result = await deps.getWorkspaceGuardrailConfig('ws-1')
+
+      expect(result).toEqual({ cost_cap_monthly_usd: 75 })
+    })
+
+    it('returns null when all configs are invalid', async () => {
+      pool.execute.mockResolvedValue([[
+        { config: 'BAD JSON' },
+      ]])
+      const deps = new PreQueryGuardDepsImpl(pool)
+
+      const result = await deps.getWorkspaceGuardrailConfig('ws-1')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('getRecentQueryCount', () => {
+    it('returns 0 when redis is not configured', async () => {
+      const deps = new PreQueryGuardDepsImpl(pool)
+
+      const result = await deps.getRecentQueryCount('ws:ws-1:user:u-1', 60)
+
+      expect(result).toBe(0)
+    })
+
+    it('increments the key and returns count minus 1', async () => {
+      mockIncr.mockResolvedValue(5)
+      const deps = new PreQueryGuardDepsImpl(pool, 'localhost', 6379)
+
+      const result = await deps.getRecentQueryCount('ws:ws-1:user:u-1', 60)
+
+      expect(result).toBe(4)
+      expect(mockIncr).toHaveBeenCalledWith('ratelimit:ws:ws-1:user:u-1')
+    })
+
+    it('sets expiry when count is 1 (new key)', async () => {
+      mockIncr.mockResolvedValue(1)
+      mockExpire.mockResolvedValue(1)
+      const deps = new PreQueryGuardDepsImpl(pool, 'localhost', 6379)
+
+      const result = await deps.getRecentQueryCount('scope', 120)
+
+      expect(result).toBe(0)
+      expect(mockExpire).toHaveBeenCalledWith('ratelimit:scope', 120)
+    })
+
+    it('does not set expiry when count is greater than 1', async () => {
+      mockIncr.mockResolvedValue(3)
+      const deps = new PreQueryGuardDepsImpl(pool, 'localhost', 6379)
+
+      await deps.getRecentQueryCount('scope', 60)
+
+      expect(mockExpire).not.toHaveBeenCalled()
+    })
+
+    it('returns 0 when redis throws an error', async () => {
+      mockIncr.mockRejectedValue(new Error('connection refused'))
+      const deps = new PreQueryGuardDepsImpl(pool, 'localhost', 6379)
+
+      const result = await deps.getRecentQueryCount('scope', 60)
+
+      expect(result).toBe(0)
+    })
+  })
+})

--- a/src/infrastructure/session/RedisSessionStore.test.ts
+++ b/src/infrastructure/session/RedisSessionStore.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { RoutingSession } from '../../application/ports/SessionStore.js'
+
+const mockGet = vi.fn()
+const mockSet = vi.fn()
+const mockDel = vi.fn()
+
+vi.mock('ioredis', () => {
+  return {
+    default: vi.fn().mockImplementation(() => ({
+      get: mockGet,
+      set: mockSet,
+      del: mockDel,
+    })),
+  }
+})
+
+vi.mock('pino', () => ({
+  default: () => ({
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+  }),
+}))
+
+import { RedisSessionStore } from './RedisSessionStore.js'
+
+const sampleSession: RoutingSession = {
+  workspaceId: 'ws-1',
+  lastMessageAt: 1700000000000,
+  routedFrom: null,
+}
+
+describe('RedisSessionStore', () => {
+  let store: RedisSessionStore
+
+  beforeEach(() => {
+    store = new RedisSessionStore('localhost', 6379)
+    vi.clearAllMocks()
+  })
+
+  describe('get', () => {
+    it('returns parsed session when key exists', async () => {
+      mockGet.mockResolvedValue(JSON.stringify(sampleSession))
+
+      const result = await store.get('session:key')
+
+      expect(result).toEqual(sampleSession)
+      expect(mockGet).toHaveBeenCalledWith('session:key')
+    })
+
+    it('returns null when key does not exist', async () => {
+      mockGet.mockResolvedValue(null)
+
+      const result = await store.get('missing-key')
+
+      expect(result).toBeNull()
+    })
+
+    it('returns null when stored value is invalid JSON', async () => {
+      mockGet.mockResolvedValue('NOT VALID JSON{{{')
+
+      const result = await store.get('bad-key')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('set', () => {
+    it('stores the session with EX TTL', async () => {
+      mockSet.mockResolvedValue('OK')
+
+      await store.set('session:key', sampleSession, 3600)
+
+      expect(mockSet).toHaveBeenCalledWith(
+        'session:key',
+        JSON.stringify(sampleSession),
+        'EX',
+        3600,
+      )
+    })
+  })
+
+  describe('delete', () => {
+    it('deletes the key from redis', async () => {
+      mockDel.mockResolvedValue(1)
+
+      await store.delete('session:key')
+
+      expect(mockDel).toHaveBeenCalledWith('session:key')
+    })
+  })
+})

--- a/src/infrastructure/vector/LanceDBVectorStore.test.ts
+++ b/src/infrastructure/vector/LanceDBVectorStore.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { VectorRecord } from '../../application/ports/VectorStore.js'
+
+// Use vi.hoisted so these are available when vi.mock factory runs (hoisted to top)
+const { mockTable, mockSearchChain, mockDb } = vi.hoisted(() => {
+  const mockSearchChain = {
+    limit: vi.fn().mockReturnThis(),
+    toArray: vi.fn().mockResolvedValue([]),
+  }
+
+  const mockTable = {
+    add: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+    vectorSearch: vi.fn().mockReturnValue(mockSearchChain),
+  }
+
+  const mockDb = {
+    tableNames: vi.fn().mockResolvedValue([]),
+    openTable: vi.fn().mockResolvedValue(mockTable),
+    createTable: vi.fn().mockResolvedValue(mockTable),
+    dropTable: vi.fn().mockResolvedValue(undefined),
+  }
+
+  return { mockTable, mockSearchChain, mockDb }
+})
+
+vi.mock('@lancedb/lancedb', () => ({
+  connect: vi.fn().mockResolvedValue(mockDb),
+}))
+
+vi.mock('pino', () => ({
+  default: () => ({
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+  }),
+}))
+
+import { LanceDBVectorStore } from './LanceDBVectorStore.js'
+
+function makeRecord(overrides: Partial<VectorRecord> = {}): VectorRecord {
+  return {
+    id: 'vec-1',
+    vector: [0.1, 0.2, 0.3],
+    text: 'sample text',
+    sourceId: 'src-1',
+    workspaceId: 'ws-1',
+    ...overrides,
+  }
+}
+
+describe('LanceDBVectorStore', () => {
+  let store: LanceDBVectorStore
+
+  beforeEach(() => {
+    store = new LanceDBVectorStore('/tmp/test-lancedb')
+    vi.clearAllMocks()
+    // Reset defaults
+    mockDb.tableNames.mockResolvedValue([])
+    mockDb.openTable.mockResolvedValue(mockTable)
+    mockTable.vectorSearch.mockReturnValue(mockSearchChain)
+    mockSearchChain.limit.mockReturnThis()
+    mockSearchChain.toArray.mockResolvedValue([])
+  })
+
+  describe('upsert', () => {
+    it('does nothing for empty records array', async () => {
+      await store.upsert('ws-1', [])
+
+      expect(mockDb.tableNames).not.toHaveBeenCalled()
+    })
+
+    it('creates a new table when it does not exist', async () => {
+      mockDb.tableNames.mockResolvedValue([])
+      const record = makeRecord()
+
+      await store.upsert('ws-1', [record])
+
+      expect(mockDb.createTable).toHaveBeenCalledWith(
+        'ws_ws_1',
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: 'vec-1',
+            text: 'sample text',
+            source_id: 'src-1',
+            workspace_id: 'ws-1',
+          }),
+        ]),
+      )
+    })
+
+    it('adds to existing table and deletes old records by source', async () => {
+      mockDb.tableNames.mockResolvedValue(['ws_ws_1'])
+      mockTable.delete.mockResolvedValue(undefined)
+      const record = makeRecord()
+
+      await store.upsert('ws-1', [record])
+
+      expect(mockDb.openTable).toHaveBeenCalledWith('ws_ws_1')
+      expect(mockTable.delete).toHaveBeenCalledWith("source_id = 'src-1'")
+      expect(mockTable.add).toHaveBeenCalled()
+    })
+
+    it('serialises metadata to JSON string', async () => {
+      mockDb.tableNames.mockResolvedValue([])
+      const record = makeRecord({ metadata: { key: 'value' } })
+
+      await store.upsert('ws-1', [record])
+
+      const rows = mockDb.createTable.mock.calls[0][1]
+      expect(rows[0].metadata_json).toBe('{"key":"value"}')
+    })
+
+    it('defaults metadata_json to empty object string', async () => {
+      mockDb.tableNames.mockResolvedValue([])
+      const record = makeRecord({ metadata: undefined })
+
+      await store.upsert('ws-1', [record])
+
+      const rows = mockDb.createTable.mock.calls[0][1]
+      expect(rows[0].metadata_json).toBe('{}')
+    })
+
+    it('sanitises workspace ID in table name', async () => {
+      mockDb.tableNames.mockResolvedValue([])
+      const record = makeRecord({ workspaceId: 'ws-special!@#chars' })
+
+      await store.upsert('ws-special!@#chars', [record])
+
+      expect(mockDb.createTable).toHaveBeenCalledWith(
+        'ws_ws_special___chars',
+        expect.any(Array),
+      )
+    })
+  })
+
+  describe('search', () => {
+    it('returns empty array when table does not exist', async () => {
+      mockDb.tableNames.mockResolvedValue([])
+
+      const results = await store.search('ws-1', [0.1, 0.2], 5)
+
+      expect(results).toEqual([])
+    })
+
+    it('returns mapped results with score', async () => {
+      mockDb.tableNames.mockResolvedValue(['ws_ws_1'])
+      mockSearchChain.toArray.mockResolvedValue([
+        {
+          id: 'vec-1',
+          text: 'hello',
+          source_id: 'src-1',
+          metadata_json: '{"tag":"test"}',
+          _distance: 0.5,
+        },
+      ])
+
+      const results = await store.search('ws-1', [0.1, 0.2], 5)
+
+      expect(results).toHaveLength(1)
+      expect(results[0]).toEqual({
+        id: 'vec-1',
+        text: 'hello',
+        sourceId: 'src-1',
+        score: 1 / (1 + 0.5),
+        metadata: { tag: 'test' },
+      })
+      expect(mockTable.vectorSearch).toHaveBeenCalledWith([0.1, 0.2])
+      expect(mockSearchChain.limit).toHaveBeenCalledWith(5)
+    })
+
+    it('skips records with invalid metadata JSON', async () => {
+      mockDb.tableNames.mockResolvedValue(['ws_ws_1'])
+      mockSearchChain.toArray.mockResolvedValue([
+        { id: 'vec-1', text: 'good', source_id: 'src-1', metadata_json: '{"ok":"yes"}', _distance: 0 },
+        { id: 'vec-2', text: 'bad', source_id: 'src-2', metadata_json: 'INVALID', _distance: 0 },
+      ])
+
+      const results = await store.search('ws-1', [0.1], 10)
+
+      expect(results).toHaveLength(1)
+      expect(results[0].id).toBe('vec-1')
+    })
+
+    it('handles null _distance with score 0', async () => {
+      mockDb.tableNames.mockResolvedValue(['ws_ws_1'])
+      mockSearchChain.toArray.mockResolvedValue([
+        { id: 'vec-1', text: 'hello', source_id: 'src-1', _distance: null },
+      ])
+
+      const results = await store.search('ws-1', [0.1], 5)
+
+      expect(results[0].score).toBe(0)
+    })
+  })
+
+  describe('deleteBySource', () => {
+    it('does nothing when table does not exist', async () => {
+      mockDb.tableNames.mockResolvedValue([])
+
+      await store.deleteBySource('ws-1', 'src-1')
+
+      expect(mockDb.openTable).not.toHaveBeenCalled()
+    })
+
+    it('deletes records matching the source ID', async () => {
+      mockDb.tableNames.mockResolvedValue(['ws_ws_1'])
+      mockTable.delete.mockResolvedValue(undefined)
+
+      await store.deleteBySource('ws-1', 'src-1')
+
+      expect(mockTable.delete).toHaveBeenCalledWith("source_id = 'src-1'")
+    })
+
+    it('handles delete errors gracefully', async () => {
+      mockDb.tableNames.mockResolvedValue(['ws_ws_1'])
+      mockTable.delete.mockRejectedValue(new Error('delete failed'))
+
+      // Should not throw
+      await store.deleteBySource('ws-1', 'src-1')
+    })
+  })
+
+  describe('deleteByWorkspace', () => {
+    it('does nothing when table does not exist', async () => {
+      mockDb.tableNames.mockResolvedValue([])
+
+      await store.deleteByWorkspace('ws-1')
+
+      expect(mockDb.dropTable).not.toHaveBeenCalled()
+    })
+
+    it('drops the table when it exists', async () => {
+      mockDb.tableNames.mockResolvedValue(['ws_ws_1'])
+
+      await store.deleteByWorkspace('ws-1')
+
+      expect(mockDb.dropTable).toHaveBeenCalledWith('ws_ws_1')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add tests for `PreQueryGuardDepsImpl` (15 tests): monthly spend queries, guardrail config merging, Redis rate limiting
- Add tests for `RedisSessionStore` (5 tests): get/set/delete operations, JSON parse error handling
- Add tests for `LanceDBVectorStore` (15 tests): upsert, search, deleteBySource, deleteByWorkspace, metadata handling

All external dependencies (mysql2, ioredis, @lancedb/lancedb) are mocked at the driver level. No production code was modified.

## Test plan
- [x] `pnpm test` passes all 404 tests across 63 files
- [x] New tests are colocated next to their source files
- [x] Follows existing vitest patterns from the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)