### PR TITLE
chore: release @supaproxy/core v1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supaproxy/core",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "type": "module",
   "exports": {
@@ -17,6 +17,7 @@
     "./domain/prompt": "./src/domain/prompt/repository.ts",
     "./ports/model": "./src/application/ports/ModelRepository.ts",
     "./ports/database": "./src/application/ports/DatabaseAdapter.ts",
+    "./ports/queue": "./src/application/ports/QueueService.ts",
     "./testing/validate-adapter": "./src/application/ports/DatabaseAdapter.test.ts",
     "./defaults": "./src/defaults.ts"
   },

--- a/src/__tests__/mocks.ts
+++ b/src/__tests__/mocks.ts
@@ -225,6 +225,9 @@ export function mockQueueService(): QueueService {
     retryAllFailed: vi.fn().mockResolvedValue(0),
     drainQueue: vi.fn().mockResolvedValue(undefined),
     listQueueNames: vi.fn().mockReturnValue(['lifecycle', 'cold-messages', 'conversation-stats']),
+    queueExists: vi.fn().mockReturnValue(true),
+    startWorkers: vi.fn().mockResolvedValue(undefined),
+    stopWorkers: vi.fn().mockResolvedValue(undefined),
   }
 }
 

--- a/src/application/ports/QueueService.ts
+++ b/src/application/ports/QueueService.ts
@@ -14,6 +14,17 @@ export interface FailedJob {
   attemptsMade: number
 }
 
+/**
+ * LifecycleHandler — the callback interface that queue workers invoke.
+ * Passed to startWorkers() so the queue adapter can trigger lifecycle scans,
+ * cold messages, and stats generation without depending on use case types.
+ */
+export interface LifecycleHandler {
+  runLifecycleScan(): Promise<void>
+  sendColdMessage(data: { conversationId: string; consumerType: string; channel: string; externalThreadId: string }): Promise<void>
+  generateStats(conversationId: string): Promise<void>
+}
+
 export interface QueueService {
   addColdMessage(data: { conversationId: string; consumerType: string; channel: string; externalThreadId: string }): Promise<void>
   addStatsJob(conversationId: string): Promise<void>
@@ -22,4 +33,7 @@ export interface QueueService {
   retryAllFailed(queueName: string): Promise<number>
   drainQueue(queueName: string): Promise<void>
   listQueueNames(): string[]
+  queueExists(name: string): boolean
+  startWorkers(handler: LifecycleHandler): Promise<void>
+  stopWorkers(): Promise<void>
 }

--- a/src/infrastructure/queue/BullMqService.ts
+++ b/src/infrastructure/queue/BullMqService.ts
@@ -1,6 +1,5 @@
 import { Queue, Worker } from 'bullmq'
-import type { QueueService, QueueJobCounts, FailedJob } from '../../application/ports/QueueService.js'
-import type { LifecycleUseCase } from '../../application/conversation/LifecycleUseCase.js'
+import type { QueueService, QueueJobCounts, FailedJob, LifecycleHandler } from '../../application/ports/QueueService.js'
 import { QUEUE_LIFECYCLE, QUEUE_COLD_MESSAGES, QUEUE_CONVERSATION_STATS, LIFECYCLE_SCAN_INTERVAL_MS, COLD_MESSAGE_CONCURRENCY, STATS_WORKER_CONCURRENCY } from '../../defaults.js'
 import pino from 'pino'
 
@@ -89,7 +88,7 @@ export class BullMqService implements QueueService {
     return name in this.queues
   }
 
-  async startWorkers(lifecycleUseCase: LifecycleUseCase): Promise<void> {
+  async startWorkers(lifecycleUseCase: LifecycleHandler): Promise<void> {
     const connection = { host: this.redisHost, port: this.redisPort }
 
     this.lifecycleWorker = new Worker(QUEUE_LIFECYCLE, async () => {


### PR DESCRIPTION
Export QueueService port. Add LifecycleHandler interface. Needed before @supaproxy/bullmq can publish.