### PR TITLE
chore: release @supaproxy/core v1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supaproxy/core",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "type": "module",
   "exports": {
@@ -18,6 +18,7 @@
     "./ports/model": "./src/application/ports/ModelRepository.ts",
     "./ports/database": "./src/application/ports/DatabaseAdapter.ts",
     "./ports/queue": "./src/application/ports/QueueService.ts",
+    "./ports/vector-store": "./src/application/ports/VectorStore.ts",
     "./testing/validate-adapter": "./src/application/ports/DatabaseAdapter.test.ts",
     "./defaults": "./src/defaults.ts"
   },


### PR DESCRIPTION
Export VectorStore port for @supaproxy/lancedb.