### PR TITLE
fix: rename env vars to be purpose-based

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,19 +16,20 @@ PORT=3001
 CORS_ORIGINS=http://localhost:4322,http://localhost:3001
 DASHBOARD_URL=http://localhost:4322
 
-# MySQL
-# Local dev (Docker mapped to host port 3308):
-DB_HOST=127.0.0.1
-DB_PORT=3308
-DB_USER=root
-DB_PASSWORD=
-DB_NAME=supaproxy
-# DB_PASSWORD must match MYSQL_ROOT_PASSWORD in the container.
-# Check with: docker inspect supaproxy-mysql --format '{{range .Config.Env}}{{println .}}{{end}}' | grep MYSQL_ROOT
+# Database (Docker mapped to host port 3308)
+DATABASE_HOST=127.0.0.1
+DATABASE_PORT=3308
+DATABASE_USER=root
+DATABASE_PASSWORD=
+DATABASE_NAME=supaproxy
 
-# Redis (Docker mapped to host port 6380)
-REDIS_HOST=127.0.0.1
-REDIS_PORT=6380
+# Queue (Docker mapped to host port 6380)
+QUEUE_HOST=127.0.0.1
+QUEUE_PORT=6380
+
+# Session store (Docker mapped to host port 6380)
+SESSION_HOST=127.0.0.1
+SESSION_PORT=6380
 
 # Audit logs
 SUPAPROXY_LOG_DIR=./var/logs

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     container_name: supaproxy-mysql
     restart: unless-stopped
     environment:
-      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${DATABASE_PASSWORD}
       MYSQL_DATABASE: supaproxy
     ports:
       - "3308:3306"
@@ -38,10 +38,12 @@ services:
       - "3001:3001"
     env_file: .env
     environment:
-      DB_HOST: mysql
-      DB_PORT: 3306
-      REDIS_HOST: redis
-      REDIS_PORT: 6379
+      DATABASE_HOST: mysql
+      DATABASE_PORT: 3306
+      QUEUE_HOST: redis
+      QUEUE_PORT: 6379
+      SESSION_HOST: redis
+      SESSION_PORT: 6379
     depends_on:
       mysql:
         condition: service_healthy

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,15 +40,19 @@ export const COOKIE_DOMAIN = (() => {
 export const PORT = requireEnvInt('PORT')
 
 // Database
-export const DB_HOST = requireEnv('DB_HOST')
-export const DB_PORT = requireEnvInt('DB_PORT')
-export const DB_USER = requireEnv('DB_USER')
-export const DB_PASSWORD = requireEnv('DB_PASSWORD')
-export const DB_NAME = requireEnv('DB_NAME')
+export const DATABASE_HOST = requireEnv('DATABASE_HOST')
+export const DATABASE_PORT = requireEnvInt('DATABASE_PORT')
+export const DATABASE_USER = requireEnv('DATABASE_USER')
+export const DATABASE_PASSWORD = requireEnv('DATABASE_PASSWORD')
+export const DATABASE_NAME = requireEnv('DATABASE_NAME')
 
-// Redis
-export const REDIS_HOST = requireEnv('REDIS_HOST')
-export const REDIS_PORT = requireEnvInt('REDIS_PORT')
+// Queue
+export const QUEUE_HOST = requireEnv('QUEUE_HOST')
+export const QUEUE_PORT = requireEnvInt('QUEUE_PORT')
+
+// Session store
+export const SESSION_HOST = requireEnv('SESSION_HOST')
+export const SESSION_PORT = requireEnvInt('SESSION_PORT')
 
 // Audit
 export const LOG_DIR = process.env.SUPAPROXY_LOG_DIR

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import pino from 'pino'
 import { createContainer } from './container.js'
 import { createApp } from './app.js'
 import { startConsumers, startWorkers } from './startup.js'
-import { PORT, DASHBOARD_URL, JWT_SECRET, IS_PRODUCTION, COOKIE_DOMAIN, REDIS_HOST, REDIS_PORT, DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME } from './config.js'
+import { PORT, DASHBOARD_URL, JWT_SECRET, IS_PRODUCTION, COOKIE_DOMAIN, QUEUE_HOST, QUEUE_PORT, SESSION_HOST, SESSION_PORT, DATABASE_HOST, DATABASE_PORT, DATABASE_USER, DATABASE_PASSWORD, DATABASE_NAME } from './config.js'
 import { createAuthRoutes } from '@supaproxy/auth'
 import { registry as guardrailRegistry, executionCatalogue, retrievalCatalogue } from '@supaproxy/guardrails'
 import { generateId, generateWorkspaceId } from './domain/shared/EntityId.js'
@@ -31,20 +31,20 @@ process.on('unhandledRejection', (reason) => {
 })
 
 // --- Init ---
-const pool = createPool({ host: DB_HOST, port: DB_PORT, user: DB_USER, password: DB_PASSWORD, database: DB_NAME })
+const pool = createPool({ host: DATABASE_HOST, port: DATABASE_PORT, user: DATABASE_USER, password: DATABASE_PASSWORD, database: DATABASE_NAME })
 await runMigrations(pool)
 
 // --- Database adapter (default: @supaproxy/mysql) ---
 const infra = createMysqlInfra(pool)
 
 // --- Queue adapter (default: @supaproxy/bullmq) ---
-const queueService = createBullMqQueue(REDIS_HOST, REDIS_PORT)
+const queueService = createBullMqQueue(QUEUE_HOST, QUEUE_PORT)
 
 // --- Vector store adapter (default: @supaproxy/lancedb) ---
 const vectorStore = createLanceDBVectors(process.env.VECTOR_STORE_PATH ?? './data/vectors')
 
 // --- Session store adapter (default: @supaproxy/redis) ---
-const sessionStore = createRedisSession(REDIS_HOST, REDIS_PORT)
+const sessionStore = createRedisSession(SESSION_HOST, SESSION_PORT)
 
 // --- Auth (default: @supaproxy/auth with JWT + bcrypt) ---
 const { routes: authRoutes, requireAuth } = createAuthRoutes({

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,7 @@
 export { createContainer, type Container } from './container.js'
 export { createApp } from './app.js'
 export { startConsumers, startWorkers } from './startup.js'
-export { PORT, CORS_ORIGINS, DASHBOARD_URL, JWT_SECRET, IS_PRODUCTION, COOKIE_DOMAIN, REDIS_HOST, REDIS_PORT, DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME } from './config.js'
+export { PORT, CORS_ORIGINS, DASHBOARD_URL, JWT_SECRET, IS_PRODUCTION, COOKIE_DOMAIN, QUEUE_HOST, QUEUE_PORT, SESSION_HOST, SESSION_PORT, DATABASE_HOST, DATABASE_PORT, DATABASE_USER, DATABASE_PASSWORD, DATABASE_NAME } from './config.js'
 export type { TenantService } from './application/ports/TenantService.js'
 export type { DatabaseAdapter } from './application/ports/DatabaseAdapter.js'
 export { generateId, generateWorkspaceId } from './domain/shared/EntityId.js'


### PR DESCRIPTION
## Summary

Rename environment variables from implementation-specific to purpose-specific:

| Before | After | Used by |
|--------|-------|---------|
| `DB_HOST` | `DATABASE_HOST` | @supaproxy/mysql |
| `DB_PORT` | `DATABASE_PORT` | @supaproxy/mysql |
| `DB_USER` | `DATABASE_USER` | @supaproxy/mysql |
| `DB_PASSWORD` | `DATABASE_PASSWORD` | @supaproxy/mysql |
| `DB_NAME` | `DATABASE_NAME` | @supaproxy/mysql |
| `REDIS_HOST` | `QUEUE_HOST` | @supaproxy/bullmq |
| `REDIS_PORT` | `QUEUE_PORT` | @supaproxy/bullmq |
| `REDIS_HOST` | `SESSION_HOST` | @supaproxy/redis |
| `REDIS_PORT` | `SESSION_PORT` | @supaproxy/redis |

Queue and session store can now point at different hosts.

## Test plan

- [x] All 369 tests pass
- [x] `.env.example` updated
- [x] `docker-compose.yaml` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)