### PR TITLE
chore: remove unused Azure AD vars from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,9 +36,3 @@ SUPAPROXY_LOG_DIR=./var/logs
 
 # Optional: vector store path (defaults to ./data/vectors)
 VECTOR_STORE_PATH=./data/vectors
-
-# Optional: Azure AD SSO
-# AZURE_AD_TENANT_ID=
-# AZURE_AD_CLIENT_ID=
-# AZURE_AD_CLIENT_SECRET=
-# AZURE_AD_REDIRECT_URI=


### PR DESCRIPTION
Never used in code.