### PR TITLE
feat: extend QueueService port with knowledge sync methods

### DIFF
--- a/src/__tests__/mocks.ts
+++ b/src/__tests__/mocks.ts
@@ -220,6 +220,9 @@ export function mockQueueService(): QueueService {
   return {
     addColdMessage: vi.fn().mockResolvedValue(undefined),
     addStatsJob: vi.fn().mockResolvedValue(undefined),
+    addKnowledgeSyncJob: vi.fn().mockResolvedValue(undefined),
+    scheduleKnowledgeSync: vi.fn().mockResolvedValue(undefined),
+    cancelKnowledgeSync: vi.fn().mockResolvedValue(undefined),
     getJobCounts: vi.fn().mockResolvedValue({ waiting: 0, active: 0, completed: 0, failed: 0, delayed: 0 }),
     getFailedJobs: vi.fn().mockResolvedValue([]),
     retryAllFailed: vi.fn().mockResolvedValue(0),

--- a/src/application/ports/QueueService.ts
+++ b/src/application/ports/QueueService.ts
@@ -19,15 +19,25 @@ export interface FailedJob {
  * Passed to startWorkers() so the queue adapter can trigger lifecycle scans,
  * cold messages, and stats generation without depending on use case types.
  */
+export interface KnowledgeSyncJobData {
+  orgId: string
+  pluginId: string
+  configId: string
+}
+
 export interface LifecycleHandler {
   runLifecycleScan(): Promise<void>
   sendColdMessage(data: { conversationId: string; consumerType: string; channel: string; externalThreadId: string }): Promise<void>
   generateStats(conversationId: string): Promise<void>
+  runKnowledgeSync?(data: KnowledgeSyncJobData): Promise<void>
 }
 
 export interface QueueService {
   addColdMessage(data: { conversationId: string; consumerType: string; channel: string; externalThreadId: string }): Promise<void>
   addStatsJob(conversationId: string): Promise<void>
+  addKnowledgeSyncJob(data: KnowledgeSyncJobData): Promise<void>
+  scheduleKnowledgeSync(configId: string, cron: string): Promise<void>
+  cancelKnowledgeSync(configId: string): Promise<void>
   getJobCounts(queueName: string): Promise<QueueJobCounts>
   getFailedJobs(queueName: string, limit: number): Promise<FailedJob[]>
   retryAllFailed(queueName: string): Promise<number>


### PR DESCRIPTION
## Summary
Extends the QueueService port to support knowledge source sync jobs.

### Changes
- `KnowledgeSyncJobData` interface
- `addKnowledgeSyncJob`, `scheduleKnowledgeSync`, `cancelKnowledgeSync` on QueueService
- Optional `runKnowledgeSync` on LifecycleHandler (cloud provides implementation)
- `QUEUE_KNOWLEDGE_SYNC` and `KNOWLEDGE_SYNC_CONCURRENCY` defaults
- Test mock updated

### Tests
369/369 passing

### Cross-repo
- BullMQ: supaproxy-bullmq feat/knowledge-sync-queue
- Cloud: supaproxy-cloud feat/sync-knowledge-execution