### PR TITLE
fix: resolve 4 SOLID violations in application layer

### DIFF
--- a/src/application/conversation/LifecycleUseCase.ts
+++ b/src/application/conversation/LifecycleUseCase.ts
@@ -1,11 +1,13 @@
 import type { ConversationRepository } from '../../domain/conversation/repository.js'
 import type { OrganisationRepository } from '../../domain/organisation/repository.js'
 import type { QueueService } from '../ports/QueueService.js'
-import type { registry as ProviderRegistryType, ProviderPlugin } from '@supaproxy/providers'
+import type { registry as ProviderRegistryType } from '@supaproxy/providers'
 import type { ConsumerPosterRegistry, ColdMessageTarget } from '../ports/ConsumerPoster.js'
+import { ConfigurationError } from '../../domain/shared/errors.js'
 import { DEFAULT_COLD_MESSAGE_MAX_TOKENS, QUEUE_COLD_MESSAGES, QUEUE_CONVERSATION_STATS, COLD_MESSAGE_TRANSCRIPT_LIMIT } from '../../defaults.js'
 import { buildColdMessagePrompt, DEFAULT_COLD_FALLBACK_MESSAGE } from '../../prompts.js'
-import { generateStats } from './StatsGenerator.js'
+import { resolveProvider } from '../query/ProviderResolver.js'
+import { StatsGenerator } from './StatsGenerator.js'
 import pino from 'pino'
 
 const log = pino({ name: 'lifecycle-use-case' })
@@ -50,20 +52,17 @@ export class LifecycleUseCase {
   }
 
   async generateStats(conversationId: string): Promise<void> {
-    return generateStats(conversationId, this.conversationRepo, (pt) => this.resolveOrgProvider(pt))
+    const generator = new StatsGenerator(this.conversationRepo, (pt) => this.resolveOrgProviderSafe(pt))
+    return generator.generate(conversationId)
   }
 
-  private async resolveOrgProvider(workspaceProviderType: string | null): Promise<{ provider: ProviderPlugin; apiKey: string } | null> {
-    const orgSettings = await this.orgRepo.getSettingValues(['ai_provider_type'])
-    const providerType = workspaceProviderType || orgSettings['ai_provider_type']
-    if (!providerType) return null
-
-    const keySettings = await this.orgRepo.getSettingValues([`${providerType}_api_key`, 'ai_api_key'])
-    const apiKey = keySettings[`${providerType}_api_key`] || keySettings['ai_api_key'] || null
-    if (!apiKey) return null
-
-    const provider = this.providerRegistry.get(providerType)
-    return { provider, apiKey }
+  private async resolveOrgProviderSafe(workspaceProviderType: string | null) {
+    try {
+      return await resolveProvider(this.orgRepo, this.providerRegistry, workspaceProviderType)
+    } catch (err) {
+      if (err instanceof ConfigurationError) return null
+      throw err
+    }
   }
 
   private async generateColdMessage(conversationId: string): Promise<string> {
@@ -73,14 +72,13 @@ export class LifecycleUseCase {
 
       const providerInfo = await this.conversationRepo.getWorkspaceProviderInfo(conversationId)
       if (!providerInfo) return ''
-      const resolved = await this.resolveOrgProvider(providerInfo.provider_type)
+      const resolved = await this.resolveOrgProviderSafe(providerInfo.provider_type)
       if (!resolved) return ''
       const { provider, apiKey } = resolved
-      const model = providerInfo.model
       const transcript = messages.slice(-COLD_MESSAGE_TRANSCRIPT_LIMIT).map(m => `${m.role}: ${m.content}`).join('\n\n')
       return provider.createSimpleMessage({
         apiKey,
-        model,
+        model: providerInfo.model,
         maxTokens: DEFAULT_COLD_MESSAGE_MAX_TOKENS,
         prompt: buildColdMessagePrompt(transcript),
       })

--- a/src/application/conversation/StatsGenerator.ts
+++ b/src/application/conversation/StatsGenerator.ts
@@ -10,60 +10,70 @@ import pino from 'pino'
 
 const log = pino({ name: 'stats-generator' })
 
-export async function generateStats(
-  conversationId: string,
-  conversationRepo: ConversationRepository,
-  resolveProvider: (providerType: string | null) => Promise<{ provider: ProviderPlugin; apiKey: string } | null>,
-): Promise<void> {
-  const existing = await conversationRepo.findStats(conversationId)
-  let statsId: string
-  if (existing) {
-    if (existing.stats_status === StatsStatus.COMPLETE) return
-    statsId = existing.id
-  } else {
-    statsId = generateId()
-    await conversationRepo.createStats(statsId, conversationId)
+export type ProviderResolver = (providerType: string | null) => Promise<{ provider: ProviderPlugin; apiKey: string } | null>
+
+export class StatsGenerator {
+  constructor(
+    private readonly conversationRepo: ConversationRepository,
+    private readonly resolveProvider: ProviderResolver,
+  ) {}
+
+  async generate(conversationId: string): Promise<void> {
+    const existing = await this.conversationRepo.findStats(conversationId)
+    let statsId: string
+    if (existing) {
+      if (existing.stats_status === StatsStatus.COMPLETE) return
+      statsId = existing.id
+    } else {
+      statsId = generateId()
+      await this.conversationRepo.createStats(statsId, conversationId)
+    }
+
+    try {
+      await this.runAnalysis(statsId, conversationId)
+    } catch (err) {
+      await this.conversationRepo.updateStatsStatus(statsId, StatsStatus.FAILED)
+      log.error({ conversationId, error: (err as Error).message }, 'Stats generation failed')
+    }
   }
 
-  try {
-    const messages = await conversationRepo.findMessages(conversationId)
+  private async runAnalysis(statsId: string, conversationId: string): Promise<void> {
+    const messages = await this.conversationRepo.findMessages(conversationId)
     if (messages.length === 0) {
-      await conversationRepo.updateStatsStatus(statsId, StatsStatus.FAILED)
+      await this.conversationRepo.updateStatsStatus(statsId, StatsStatus.FAILED)
       return
     }
 
-    const aggregate = await conversationRepo.getAggregateData(conversationId)
-    const timestamps = await conversationRepo.getTimestamps(conversationId)
-    const providerInfo = await conversationRepo.getWorkspaceProviderInfo(conversationId)
+    const aggregate = await this.conversationRepo.getAggregateData(conversationId)
+    const timestamps = await this.conversationRepo.getTimestamps(conversationId)
+    const providerInfo = await this.conversationRepo.getWorkspaceProviderInfo(conversationId)
 
     if (!providerInfo) {
-      await conversationRepo.updateStatsStatus(statsId, StatsStatus.FAILED)
+      await this.conversationRepo.updateStatsStatus(statsId, StatsStatus.FAILED)
       return
     }
 
-    const resolved = await resolveProvider(providerInfo.provider_type)
+    const resolved = await this.resolveProvider(providerInfo.provider_type)
     if (!resolved) {
-      await conversationRepo.updateStatsStatus(statsId, StatsStatus.FAILED)
+      await this.conversationRepo.updateStatsStatus(statsId, StatsStatus.FAILED)
       return
     }
-    const { provider, apiKey } = resolved
-    const model = providerInfo.model
 
     const durationSec = timestamps?.first_message_at && timestamps?.closed_at
       ? Duration.fromMs(new Date(timestamps.closed_at).getTime() - new Date(timestamps.first_message_at).getTime()).seconds
       : 0
 
     const transcript = messages.map(m => `${m.role}: ${m.content}`).join('\n\n')
-    const analysisText = await provider.createSimpleMessage({
-      apiKey,
-      model,
+    const analysisText = await resolved.provider.createSimpleMessage({
+      apiKey: resolved.apiKey,
+      model: providerInfo.model,
       maxTokens: DEFAULT_STATS_ANALYSIS_MAX_TOKENS,
       prompt: buildAnalysisPrompt(transcript),
     })
 
     const parsed = parseStatsAnalysis(analysisText)
 
-    await conversationRepo.updateStatsComplete(statsId, {
+    await this.conversationRepo.updateStatsComplete(statsId, {
       sentimentScore: (parsed.sentiment_score as number) || DEFAULT_SENTIMENT_SCORE,
       resolutionStatus: (parsed.resolution_status as string) || 'unresolved',
       complianceViolations: JSON.stringify(parsed.compliance_violations || []),
@@ -81,9 +91,6 @@ export async function generateStats(
     })
 
     log.info({ conversationId, sentiment: parsed.sentiment_score, resolution: parsed.resolution_status }, 'Conversation stats generated')
-  } catch (err) {
-    await conversationRepo.updateStatsStatus(statsId, StatsStatus.FAILED)
-    log.error({ conversationId, error: (err as Error).message }, 'Stats generation failed')
   }
 }
 

--- a/src/application/oauth/ExchangeOAuthCodeUseCase.ts
+++ b/src/application/oauth/ExchangeOAuthCodeUseCase.ts
@@ -21,7 +21,7 @@ export class ExchangeOAuthCodeUseCase {
   ) {}
 
   async execute(code: string, state: string): Promise<ExchangeResult> {
-    const pluginId = OAuthState.parse(state)
+    const pluginId = state.split(':')[0] || null
     if (!pluginId) throw new Error(ERROR_PLUGIN_NOT_FOUND)
 
     const config = await this.credentialPort.resolveOAuthConfig(pluginId)
@@ -65,12 +65,5 @@ export class ExchangeOAuthCodeUseCase {
       await this.orgRepo.upsertSetting(generateId(), orgId, `${pluginId}_resource_id`, resources[0].id, false)
       await this.orgRepo.upsertSetting(generateId(), orgId, `${pluginId}_resource_url`, resources[0].url || resources[0].name, false)
     }
-  }
-}
-
-class OAuthState {
-  static parse(state: string): string | null {
-    const pluginId = state.split(':')[0]
-    return pluginId || null
   }
 }

--- a/src/application/query/ExecuteQueryUseCase.test.ts
+++ b/src/application/query/ExecuteQueryUseCase.test.ts
@@ -9,6 +9,7 @@ import {
   stubWorkspace,
 } from '../../__tests__/mocks.js'
 import { ExecuteQueryUseCase } from './ExecuteQueryUseCase.js'
+import { ToolCallProcessor } from './ToolCallProcessor.js'
 import type { ManageConversationUseCase } from '../conversation/ManageConversationUseCase.js'
 import type { registry as ProviderRegistryType, ProviderPlugin } from '@supaproxy/providers'
 import type { GuardrailPlugin } from '@supaproxy/guardrails'
@@ -74,6 +75,7 @@ describe('ExecuteQueryUseCase', () => {
       providerRegistry,
       mcpFactory,
       conversationUseCase,
+      new ToolCallProcessor(),
       resolveGuardrails,
     )
   }
@@ -507,7 +509,7 @@ describe('ExecuteQueryUseCase', () => {
 
       const useCase = new ExecuteQueryUseCase(
         workspaceRepo, orgRepo, auditRepo, providerRegistry, mcpFactory,
-        conversationUseCase, resolveGuardrails, undefined, resolveExec,
+        conversationUseCase, new ToolCallProcessor(), resolveGuardrails, undefined, resolveExec,
       )
 
       const result = await useCase.execute('ws-test', 'What is my balance?', baseMeta)
@@ -534,7 +536,7 @@ describe('ExecuteQueryUseCase', () => {
 
       const useCase = new ExecuteQueryUseCase(
         workspaceRepo, orgRepo, auditRepo, providerRegistry, mcpFactory,
-        conversationUseCase, resolveGuardrails, undefined, resolveExec, undefined, eventRepo,
+        conversationUseCase, new ToolCallProcessor(eventRepo), resolveGuardrails, undefined, resolveExec,
       )
 
       await useCase.execute('ws-test', 'What is my balance?', baseMeta)
@@ -571,7 +573,7 @@ describe('ExecuteQueryUseCase', () => {
 
       const useCase = new ExecuteQueryUseCase(
         workspaceRepo, orgRepo, auditRepo, providerRegistry, mcpFactory,
-        conversationUseCase, resolveGuardrails, undefined, resolveExec,
+        conversationUseCase, new ToolCallProcessor(), resolveGuardrails, undefined, resolveExec,
       )
 
       const result = await useCase.execute('ws-test', 'Please delete my account', baseMeta)
@@ -617,7 +619,7 @@ describe('ExecuteQueryUseCase', () => {
 
       const useCase = new ExecuteQueryUseCase(
         workspaceRepo, orgRepo, auditRepo, providerRegistry, mcpFactory,
-        conversationUseCase, resolveGuardrails, undefined, undefined, resolveRetrieval,
+        conversationUseCase, new ToolCallProcessor(), resolveGuardrails, undefined, undefined, resolveRetrieval,
       )
 
       await useCase.execute('ws-test', 'Fetch this page', baseMeta)
@@ -672,7 +674,7 @@ describe('ExecuteQueryUseCase', () => {
 
       const useCase = new ExecuteQueryUseCase(
         workspaceRepo, orgRepo, auditRepo, providerRegistry, mcpFactory,
-        conversationUseCase, resolveGuardrails, undefined, undefined, resolveRetrieval, eventRepo,
+        conversationUseCase, new ToolCallProcessor(eventRepo), resolveGuardrails, undefined, undefined, resolveRetrieval,
       )
 
       await useCase.execute('ws-test', 'Search for data', baseMeta)

--- a/src/application/query/ExecuteQueryUseCase.ts
+++ b/src/application/query/ExecuteQueryUseCase.ts
@@ -3,7 +3,6 @@ import type { OrganisationRepository } from '../../domain/organisation/repositor
 import type { AuditLogRepository } from '../../domain/audit/repository.js'
 import type { ProviderPlugin, registry as ProviderRegistryType } from '@supaproxy/providers'
 import type { GuardrailPlugin, ExecutionRailRegistry, RetrievalRailRegistry } from '@supaproxy/guardrails'
-import type { GuardrailEventRepository } from '../../domain/guardrail/repository.js'
 import type { McpClientFactory, McpConnection } from '../ports/McpClient.js'
 import type { ManageConversationUseCase } from '../conversation/ManageConversationUseCase.js'
 import { generateId } from '../../domain/shared/EntityId.js'
@@ -13,7 +12,8 @@ import { ERROR_CODES } from '../../prompts.js'
 import type { PromptResolver } from '../prompt/PromptResolver.js'
 import type { PreQueryGuardService } from './PreQueryGuardService.js'
 import type { RetrieveKnowledgeForWorkspaceUseCase } from '../knowledge/RetrieveKnowledgeForWorkspaceUseCase.js'
-import { ToolCallProcessor, type ToolEntry } from './ToolCallProcessor.js'
+import type { ToolCallProcessor } from './ToolCallProcessor.js'
+import type { ToolEntry } from './ToolCallProcessor.js'
 import { runAgentLoop, buildEmptyResult, buildQueryResult, buildAuditLogData, recordMessages, type QueryMeta, type QueryResult, type AgentLoopResult } from './AgentLoopHelpers.js'
 import { resolveProvider } from './ProviderResolver.js'
 import { discoverTools } from './ToolDiscovery.js'
@@ -24,7 +24,6 @@ import pino from 'pino'
 const log = pino({ name: 'execute-query' })
 
 export class ExecuteQueryUseCase {
-  private readonly toolCallProcessor: ToolCallProcessor
   constructor(
     private readonly workspaceRepo: WorkspaceRepository,
     private readonly orgRepo: OrganisationRepository,
@@ -32,16 +31,14 @@ export class ExecuteQueryUseCase {
     private readonly providerRegistry: typeof ProviderRegistryType,
     private readonly mcpFactory: McpClientFactory,
     private readonly conversationUseCase: ManageConversationUseCase,
+    private readonly toolCallProcessor: ToolCallProcessor,
     private readonly resolveGuardrails: (workspaceId: string) => Promise<GuardrailPlugin[]> = async () => [],
     private readonly promptResolver?: PromptResolver,
     private readonly resolveExecutionRails: (workspaceId: string) => Promise<ExecutionRailRegistry | null> = async () => null,
     private readonly resolveRetrievalRails: (workspaceId: string) => Promise<RetrievalRailRegistry | null> = async () => null,
-    private readonly guardrailEventRepo?: GuardrailEventRepository,
     private readonly preQueryGuard?: PreQueryGuardService,
     private readonly retrieveKnowledge?: RetrieveKnowledgeForWorkspaceUseCase,
-  ) {
-    this.toolCallProcessor = new ToolCallProcessor(guardrailEventRepo)
-  }
+  ) {}
 
   async execute(workspaceId: string, query: string, meta: QueryMeta): Promise<QueryResult> {
     const startTime = Date.now()

--- a/src/application/routing/RouteMessageUseCase.test.ts
+++ b/src/application/routing/RouteMessageUseCase.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mockOrgRepo, mockWorkspaceRepo, mockConversationRepo, mockManageConversationUseCase, stubWorkspace } from '../../__tests__/mocks.js'
 import { RouteMessageUseCase } from './RouteMessageUseCase.js'
+import { WorkspaceMatcher } from './WorkspaceMatcher.js'
+import { ReceptionistRouter } from './ReceptionistRouter.js'
 import type { SessionStore } from '../ports/SessionStore.js'
 import type { ExecuteQueryUseCase } from '../query/ExecuteQueryUseCase.js'
 import type { ManageConversationUseCase } from '../conversation/ManageConversationUseCase.js'
@@ -52,7 +54,11 @@ describe('RouteMessageUseCase', () => {
     workspaceRepo = mockWorkspaceRepo()
     sessionStore = mockSessionStore()
     executeQuery = mockExecuteQuery()
-    useCase = new RouteMessageUseCase(workspaceRepo, orgRepo, mockConversationRepo(), sessionStore, executeQuery, mockManageConversationUseCase() as ManageConversationUseCase)
+    const convRepo = mockConversationRepo()
+    const convUseCase = mockManageConversationUseCase() as ManageConversationUseCase
+    const matcher = new WorkspaceMatcher(workspaceRepo, orgRepo, executeQuery)
+    const router = new ReceptionistRouter(workspaceRepo, convRepo, sessionStore, convUseCase, matcher)
+    useCase = new RouteMessageUseCase(workspaceRepo, sessionStore, executeQuery, convUseCase, matcher, router)
   })
 
   it('uses existing session to route directly to workspace', async () => {
@@ -358,7 +364,10 @@ describe('RouteMessageUseCase', () => {
 
   it('records routing metadata on conversation when routing happens', async () => {
     const conversationRepo = mockConversationRepo()
-    const localUseCase = new RouteMessageUseCase(workspaceRepo, orgRepo, conversationRepo, sessionStore, executeQuery, mockManageConversationUseCase() as ManageConversationUseCase)
+    const localConvUseCase = mockManageConversationUseCase() as ManageConversationUseCase
+    const localMatcher = new WorkspaceMatcher(workspaceRepo, orgRepo, executeQuery)
+    const localRouter = new ReceptionistRouter(workspaceRepo, conversationRepo, sessionStore, localConvUseCase, localMatcher)
+    const localUseCase = new RouteMessageUseCase(workspaceRepo, sessionStore, executeQuery, localConvUseCase, localMatcher, localRouter)
 
     const defaultWs = stubWorkspace({ id: 'ws-general', name: '#general', is_default: true })
     const targetWs = stubWorkspace({ id: 'ws-insurance', name: 'Insurance' })
@@ -466,9 +475,10 @@ describe('RouteMessageUseCase', () => {
   it('logs messages to #general master conversation after routing', async () => {
     const mockConvUseCase = mockManageConversationUseCase()
 
-    const localUseCase = new RouteMessageUseCase(
-      workspaceRepo, orgRepo, mockConversationRepo(), sessionStore, executeQuery, mockConvUseCase as ManageConversationUseCase,
-    )
+    const localConvRepo = mockConversationRepo()
+    const localMatcher = new WorkspaceMatcher(workspaceRepo, orgRepo, executeQuery)
+    const localRouter = new ReceptionistRouter(workspaceRepo, localConvRepo, sessionStore, mockConvUseCase as ManageConversationUseCase, localMatcher)
+    const localUseCase = new RouteMessageUseCase(workspaceRepo, sessionStore, executeQuery, mockConvUseCase as ManageConversationUseCase, localMatcher, localRouter)
 
     // Session on target workspace with generalConversationId set
     vi.mocked(sessionStore.get).mockResolvedValue({
@@ -508,9 +518,10 @@ describe('RouteMessageUseCase', () => {
       { role: 'assistant', content: 'Connecting you to Insurance.' },
     ])
 
-    const localUseCase = new RouteMessageUseCase(
-      workspaceRepo, orgRepo, mockConversationRepo(), sessionStore, executeQuery, mockConvUseCase as ManageConversationUseCase,
-    )
+    const localConvRepo = mockConversationRepo()
+    const localMatcher = new WorkspaceMatcher(workspaceRepo, orgRepo, executeQuery)
+    const localRouter = new ReceptionistRouter(workspaceRepo, localConvRepo, sessionStore, mockConvUseCase as ManageConversationUseCase, localMatcher)
+    const localUseCase = new RouteMessageUseCase(workspaceRepo, sessionStore, executeQuery, mockConvUseCase as ManageConversationUseCase, localMatcher, localRouter)
 
     // Session already routed to insurance with receptionist conversation ID
     vi.mocked(sessionStore.get).mockResolvedValue({

--- a/src/application/routing/RouteMessageUseCase.ts
+++ b/src/application/routing/RouteMessageUseCase.ts
@@ -1,12 +1,10 @@
 import type { WorkspaceRepository } from '../../domain/workspace/repository.js'
-import type { OrganisationRepository } from '../../domain/organisation/repository.js'
-import type { ConversationRepository } from '../../domain/conversation/repository.js'
 import type { SessionStore, RoutingSession } from '../ports/SessionStore.js'
 import { buildSessionKey } from '../ports/SessionStore.js'
 import type { ExecuteQueryUseCase } from '../query/ExecuteQueryUseCase.js'
 import type { ManageConversationUseCase } from '../conversation/ManageConversationUseCase.js'
-import { WorkspaceMatcher } from './WorkspaceMatcher.js'
-import { ReceptionistRouter } from './ReceptionistRouter.js'
+import type { WorkspaceMatcher } from './WorkspaceMatcher.js'
+import type { ReceptionistRouter } from './ReceptionistRouter.js'
 import { SESSION_TTL_SECONDS } from '../../defaults.js'
 import { isRedirectOffer } from '../../prompts.js'
 import pino from 'pino'
@@ -31,20 +29,14 @@ interface RouteMessageOutput {
 }
 
 export class RouteMessageUseCase {
-  private readonly matcher: WorkspaceMatcher
-  private readonly router: ReceptionistRouter
-
   constructor(
     private readonly workspaceRepo: WorkspaceRepository,
-    private readonly orgRepo: OrganisationRepository,
-    private readonly conversationRepo: ConversationRepository,
     private readonly sessionStore: SessionStore,
     private readonly executeQueryUseCase: ExecuteQueryUseCase,
     private readonly conversationUseCase: ManageConversationUseCase,
-  ) {
-    this.matcher = new WorkspaceMatcher(workspaceRepo, orgRepo, executeQueryUseCase)
-    this.router = new ReceptionistRouter(workspaceRepo, conversationRepo, sessionStore, conversationUseCase, this.matcher)
-  }
+    private readonly matcher: WorkspaceMatcher,
+    private readonly router: ReceptionistRouter,
+  ) {}
 
   async execute(input: RouteMessageInput): Promise<RouteMessageOutput> {
     const sessionKey = buildSessionKey(input.consumerType, input.entryPoint, input.userId)

--- a/src/container.ts
+++ b/src/container.ts
@@ -68,9 +68,12 @@ import { ConnectConsumerUseCase } from './application/connector/ConnectConsumerU
 
 // Application - Query
 import { ExecuteQueryUseCase } from './application/query/ExecuteQueryUseCase.js'
+import { ToolCallProcessor } from './application/query/ToolCallProcessor.js'
 
 // Application - Routing
 import { RouteMessageUseCase } from './application/routing/RouteMessageUseCase.js'
+import { WorkspaceMatcher } from './application/routing/WorkspaceMatcher.js'
+import { ReceptionistRouter } from './application/routing/ReceptionistRouter.js'
 
 // Application - Queue
 import { ManageQueuesUseCase } from './application/queue/ManageQueuesUseCase.js'
@@ -233,9 +236,12 @@ export function createContainer(infra: DatabaseAdapter, options: ContainerOption
     getRecentQueryCount: (scope, window) => options.sessionStore.getRecentQueryCount(scope, window),
   }
   const preQueryGuard = new PreQueryGuardService(preQueryGuardDeps)
-  const executeQueryUseCase = new ExecuteQueryUseCase(workspaceRepo, orgRepo, auditRepo, providerRegistry, mcpFactory, manageConversationUseCase, resolveGuardrails, promptResolver, resolveExecutionRails, resolveRetrievalRails, guardrailEventRepo, preQueryGuard, retrieveKnowledge)
+  const toolCallProcessor = new ToolCallProcessor(guardrailEventRepo)
+  const executeQueryUseCase = new ExecuteQueryUseCase(workspaceRepo, orgRepo, auditRepo, providerRegistry, mcpFactory, manageConversationUseCase, toolCallProcessor, resolveGuardrails, promptResolver, resolveExecutionRails, resolveRetrievalRails, preQueryGuard, retrieveKnowledge)
   const { sessionStore } = options
-  const routeMessageUseCase = new RouteMessageUseCase(workspaceRepo, orgRepo, conversationRepo, sessionStore, executeQueryUseCase, manageConversationUseCase)
+  const workspaceMatcher = new WorkspaceMatcher(workspaceRepo, orgRepo, executeQueryUseCase)
+  const receptionistRouter = new ReceptionistRouter(workspaceRepo, conversationRepo, sessionStore, manageConversationUseCase, workspaceMatcher)
+  const routeMessageUseCase = new RouteMessageUseCase(workspaceRepo, sessionStore, executeQueryUseCase, manageConversationUseCase, workspaceMatcher, receptionistRouter)
   const manageQueuesUseCase = new ManageQueuesUseCase(queueService)
 
   // Build routes (auth routes injected from outside)


### PR DESCRIPTION
## Summary

- **Inject ToolCallProcessor** into ExecuteQueryUseCase (was `new`-ed inline, untestable independently)
- **Inject WorkspaceMatcher + ReceptionistRouter** into RouteMessageUseCase (construction moved to container.ts)
- **Deduplicate provider resolution** in LifecycleUseCase (uses shared `resolveProvider()` from ProviderResolver)
- **Convert StatsGenerator** to class with `generate()` method (was standalone function with callback DI)
- Removed unnecessary `OAuthState` inner class

## Test plan

- [x] 438 tests pass across 68 files
- [x] `tsc --noEmit` clean
- [x] All test constructors updated to match new signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)