### PR TITLE
fix: resolve final 5 DDD/SOLID violations from full codebase pass

### DIFF
--- a/src/application/conversation/LifecycleUseCase.test.ts
+++ b/src/application/conversation/LifecycleUseCase.test.ts
@@ -3,6 +3,7 @@ import {
   mockConversationRepo, mockOrgRepo, mockQueueService, mockPosterRegistry,
 } from '../../__tests__/mocks.js'
 import { LifecycleUseCase } from './LifecycleUseCase.js'
+import { StatsGenerator } from './StatsGenerator.js'
 import type { registry as ProviderRegistryType, ProviderPlugin } from '@supaproxy/providers'
 import type { ColdTransitionData, ConversationStatsData } from '../../domain/conversation/repository.js'
 
@@ -52,7 +53,17 @@ describe('LifecycleUseCase', () => {
     providerPlugin = mockProviderPlugin()
     providerRegistry = mockProviderRegistry(providerPlugin)
     posterRegistry = mockPosterRegistry()
-    useCase = new LifecycleUseCase(conversationRepo, orgRepo, queueService, providerRegistry, posterRegistry)
+    const resolveProviderSafe = async (pt: string | null) => {
+      const orgSettings = await orgRepo.getSettingValues(['ai_provider_type'])
+      const providerType = pt || orgSettings['ai_provider_type']
+      if (!providerType) return null
+      const keySettings = await orgRepo.getSettingValues([`${providerType}_api_key`, 'ai_api_key'])
+      const apiKey = keySettings[`${providerType}_api_key`] || keySettings['ai_api_key'] || null
+      if (!apiKey) return null
+      return { provider: providerRegistry.get(providerType), apiKey }
+    }
+    const statsGenerator = new StatsGenerator(conversationRepo, resolveProviderSafe)
+    useCase = new LifecycleUseCase(conversationRepo, orgRepo, queueService, providerRegistry, posterRegistry, statsGenerator)
   })
 
   // ── runLifecycleScan ──

--- a/src/application/conversation/LifecycleUseCase.ts
+++ b/src/application/conversation/LifecycleUseCase.ts
@@ -7,7 +7,7 @@ import { ConfigurationError } from '../../domain/shared/errors.js'
 import { DEFAULT_COLD_MESSAGE_MAX_TOKENS, QUEUE_COLD_MESSAGES, QUEUE_CONVERSATION_STATS, COLD_MESSAGE_TRANSCRIPT_LIMIT } from '../../defaults.js'
 import { buildColdMessagePrompt, DEFAULT_COLD_FALLBACK_MESSAGE } from '../../prompts.js'
 import { resolveProvider } from '../query/ProviderResolver.js'
-import { StatsGenerator } from './StatsGenerator.js'
+import type { StatsGenerator } from './StatsGenerator.js'
 import pino from 'pino'
 
 const log = pino({ name: 'lifecycle-use-case' })
@@ -19,6 +19,7 @@ export class LifecycleUseCase {
     private readonly queueService: QueueService,
     private readonly providerRegistry: typeof ProviderRegistryType,
     private readonly posterRegistry: ConsumerPosterRegistry,
+    private readonly statsGenerator: StatsGenerator,
   ) {}
 
   async runLifecycleScan(): Promise<void> {
@@ -52,8 +53,7 @@ export class LifecycleUseCase {
   }
 
   async generateStats(conversationId: string): Promise<void> {
-    const generator = new StatsGenerator(this.conversationRepo, (pt) => this.resolveOrgProviderSafe(pt))
-    return generator.generate(conversationId)
+    return this.statsGenerator.generate(conversationId)
   }
 
   private async resolveOrgProviderSafe(workspaceProviderType: string | null) {

--- a/src/application/oauth/DisconnectOAuthUseCase.test.ts
+++ b/src/application/oauth/DisconnectOAuthUseCase.test.ts
@@ -41,6 +41,6 @@ describe('DisconnectOAuthUseCase', () => {
   it('throws when no org exists', async () => {
     vi.mocked(orgRepo.getFirstOrgId).mockResolvedValue(null)
 
-    await expect(useCase.execute('test-plugin')).rejects.toThrow('no_org')
+    await expect(useCase.execute('test-plugin')).rejects.toThrow('No organisation configured')
   })
 })

--- a/src/application/oauth/DisconnectOAuthUseCase.ts
+++ b/src/application/oauth/DisconnectOAuthUseCase.ts
@@ -1,5 +1,6 @@
 import type { OrganisationRepository } from '../../domain/organisation/repository.js'
-import { OAUTH_SETTING_SUFFIXES, ERROR_NO_ORG } from '../../defaults.js'
+import { OAUTH_SETTING_SUFFIXES } from '../../defaults.js'
+import { ConfigurationError } from '../../domain/shared/errors.js'
 import pino from 'pino'
 
 const log = pino({ name: 'disconnect-oauth' })
@@ -11,7 +12,7 @@ export class DisconnectOAuthUseCase {
 
   async execute(pluginId: string): Promise<{ disconnected: boolean }> {
     const orgId = await this.orgRepo.getFirstOrgId()
-    if (!orgId) throw new Error(ERROR_NO_ORG)
+    if (!orgId) throw new ConfigurationError('No organisation configured')
 
     for (const suffix of OAUTH_SETTING_SUFFIXES) {
       const key = `${pluginId}_${suffix}`

--- a/src/application/oauth/ExchangeOAuthCodeUseCase.test.ts
+++ b/src/application/oauth/ExchangeOAuthCodeUseCase.test.ts
@@ -54,17 +54,17 @@ describe('ExchangeOAuthCodeUseCase', () => {
 
   it('throws when plugin not found', async () => {
     vi.mocked(credentialPort.resolveOAuthConfig).mockResolvedValue(null)
-    await expect(useCase.execute('code', 'test-plugin:nonce')).rejects.toThrow('plugin_not_found')
+    await expect(useCase.execute('code', 'test-plugin:nonce')).rejects.toThrow('not found')
   })
 
   it('throws when no org exists', async () => {
     vi.mocked(orgRepo.getFirstOrgId).mockResolvedValue(null)
-    await expect(useCase.execute('code', 'test-plugin:nonce')).rejects.toThrow('no_org')
+    await expect(useCase.execute('code', 'test-plugin:nonce')).rejects.toThrow('No organisation configured')
   })
 
   it('throws when credentials are missing', async () => {
     vi.mocked(credentialPort.resolveCredentials).mockResolvedValue(null)
-    await expect(useCase.execute('code', 'test-plugin:nonce')).rejects.toThrow('no_credentials')
+    await expect(useCase.execute('code', 'test-plugin:nonce')).rejects.toThrow('No OAuth credentials configured')
   })
 
   it('throws when token exchange fails', async () => {

--- a/src/application/oauth/ExchangeOAuthCodeUseCase.ts
+++ b/src/application/oauth/ExchangeOAuthCodeUseCase.ts
@@ -2,7 +2,7 @@ import type { OrganisationRepository } from '../../domain/organisation/repositor
 import type { OAuthCredentialPort } from './OAuthCredentialService.js'
 import type { OAuthHttpClient } from '../ports/OAuthHttpClient.js'
 import { generateId } from '../../domain/shared/EntityId.js'
-import { ERROR_NO_ORG, ERROR_NO_CREDENTIALS, ERROR_PLUGIN_NOT_FOUND } from '../../defaults.js'
+import { NotFoundError, ConfigurationError } from '../../domain/shared/errors.js'
 import pino from 'pino'
 
 const log = pino({ name: 'exchange-oauth-code' })
@@ -22,16 +22,16 @@ export class ExchangeOAuthCodeUseCase {
 
   async execute(code: string, state: string): Promise<ExchangeResult> {
     const pluginId = state.split(':')[0] || null
-    if (!pluginId) throw new Error(ERROR_PLUGIN_NOT_FOUND)
+    if (!pluginId) throw new NotFoundError('Plugin', state)
 
     const config = await this.credentialPort.resolveOAuthConfig(pluginId)
-    if (!config) throw new Error(ERROR_PLUGIN_NOT_FOUND)
+    if (!config) throw new NotFoundError('Plugin', pluginId)
 
     const orgId = await this.orgRepo.getFirstOrgId()
-    if (!orgId) throw new Error(ERROR_NO_ORG)
+    if (!orgId) throw new ConfigurationError('No organisation configured')
 
     const credentials = await this.credentialPort.resolveCredentials(orgId, pluginId)
-    if (!credentials) throw new Error(ERROR_NO_CREDENTIALS)
+    if (!credentials) throw new ConfigurationError('No OAuth credentials configured')
 
     const tokens = await this.oauthHttp.exchangeToken({
       tokenUrl: config.tokenUrl,

--- a/src/application/oauth/RefreshOAuthTokenUseCase.test.ts
+++ b/src/application/oauth/RefreshOAuthTokenUseCase.test.ts
@@ -51,12 +51,12 @@ describe('RefreshOAuthTokenUseCase', () => {
 
   it('throws when plugin not found', async () => {
     vi.mocked(credentialPort.resolveOAuthConfig).mockResolvedValue(null)
-    await expect(useCase.execute('test-plugin')).rejects.toThrow('plugin_not_found')
+    await expect(useCase.execute('test-plugin')).rejects.toThrow('not found')
   })
 
   it('throws when no refresh token exists', async () => {
     vi.mocked(orgRepo.findSetting).mockResolvedValue(null)
-    await expect(useCase.execute('test-plugin')).rejects.toThrow('no_refresh_token')
+    await expect(useCase.execute('test-plugin')).rejects.toThrow('No refresh token available')
   })
 
   it('throws when token exchange fails', async () => {

--- a/src/application/oauth/RefreshOAuthTokenUseCase.ts
+++ b/src/application/oauth/RefreshOAuthTokenUseCase.ts
@@ -2,7 +2,7 @@ import type { OrganisationRepository } from '../../domain/organisation/repositor
 import type { OAuthCredentialPort } from './OAuthCredentialService.js'
 import type { OAuthHttpClient } from '../ports/OAuthHttpClient.js'
 import { generateId } from '../../domain/shared/EntityId.js'
-import { ERROR_NO_ORG, ERROR_NO_CREDENTIALS, ERROR_NO_REFRESH_TOKEN, ERROR_PLUGIN_NOT_FOUND } from '../../defaults.js'
+import { NotFoundError, ConfigurationError } from '../../domain/shared/errors.js'
 import pino from 'pino'
 
 const log = pino({ name: 'refresh-oauth-token' })
@@ -16,16 +16,16 @@ export class RefreshOAuthTokenUseCase {
 
   async execute(pluginId: string): Promise<{ refreshed: boolean }> {
     const config = await this.credentialPort.resolveOAuthConfig(pluginId)
-    if (!config) throw new Error(ERROR_PLUGIN_NOT_FOUND)
+    if (!config) throw new NotFoundError('Plugin', pluginId)
 
     const orgId = await this.orgRepo.getFirstOrgId()
-    if (!orgId) throw new Error(ERROR_NO_ORG)
+    if (!orgId) throw new ConfigurationError('No organisation configured')
 
     const refreshToken = await this.orgRepo.findSetting(orgId, `${pluginId}_refresh_token`)
-    if (!refreshToken?.value) throw new Error(ERROR_NO_REFRESH_TOKEN)
+    if (!refreshToken?.value) throw new ConfigurationError('No refresh token available')
 
     const credentials = await this.credentialPort.resolveCredentials(orgId, pluginId)
-    if (!credentials) throw new Error(ERROR_NO_CREDENTIALS)
+    if (!credentials) throw new ConfigurationError('No OAuth credentials configured')
 
     const tokens = await this.oauthHttp.exchangeToken({
       tokenUrl: config.tokenUrl,

--- a/src/container.ts
+++ b/src/container.ts
@@ -69,6 +69,10 @@ import { ConnectConsumerUseCase } from './application/connector/ConnectConsumerU
 // Application - Query
 import { ExecuteQueryUseCase } from './application/query/ExecuteQueryUseCase.js'
 import { ToolCallProcessor } from './application/query/ToolCallProcessor.js'
+import { FetchOAuthHttpClient } from './infrastructure/oauth/FetchOAuthHttpClient.js'
+import { StatsGenerator } from './application/conversation/StatsGenerator.js'
+import { safeJsonParse } from './shared/json.js'
+import { resolveProvider } from './application/query/ProviderResolver.js'
 
 // Application - Routing
 import { RouteMessageUseCase } from './application/routing/RouteMessageUseCase.js'
@@ -163,7 +167,12 @@ export function createContainer(infra: DatabaseAdapter, options: ContainerOption
   const getConversationDetailUseCase = new GetConversationDetailUseCase(conversationRepo)
   const manageConversationUseCase = new ManageConversationUseCase(conversationRepo)
   const closeConversationUseCase = new CloseConversationUseCase(conversationRepo, queueService)
-  const lifecycleUseCase = new LifecycleUseCase(conversationRepo, orgRepo, queueService, providerRegistry, posterRegistry)
+  const resolveProviderSafe = async (pt: string | null) => {
+    try { return await resolveProvider(orgRepo, providerRegistry, pt) }
+    catch { return null }
+  }
+  const statsGenerator = new StatsGenerator(conversationRepo, resolveProviderSafe)
+  const lifecycleUseCase = new LifecycleUseCase(conversationRepo, orgRepo, queueService, providerRegistry, posterRegistry, statsGenerator)
 
   const testMcpConnectionUseCase = new TestMcpConnectionUseCase(mcpFactory)
   const saveMcpConnectionUseCase = new SaveMcpConnectionUseCase(workspaceRepo, mcpFactory)
@@ -197,7 +206,7 @@ export function createContainer(infra: DatabaseAdapter, options: ContainerOption
           getWorkspaceForChannel: async (channelId: string): Promise<Workspace | null> => {
             const consumers = await workspaceRepo.findConsumersByType(plugin.type)
             for (const row of consumers) {
-              const cfg = typeof row.config === 'string' ? JSON.parse(row.config) : row.config
+              const cfg = typeof row.config === 'string' ? safeJsonParse<{ channels?: string[] }>(row.config, {}) : row.config
               if ((cfg.channels || []).includes(channelId)) {
                 return { id: row.workspace_id, name: '' }
               }
@@ -268,7 +277,7 @@ export function createContainer(infra: DatabaseAdapter, options: ContainerOption
 
   // OAuth routes (optional, only if providers are configured)
   const oauthRoutes = options.oauth
-    ? createOAuthRoutes({ orgRepo, requireAuth, dashboardUrl: options.oauth.dashboardUrl, credentialPort: options.oauth.credentialPort })
+    ? createOAuthRoutes({ orgRepo, requireAuth, dashboardUrl: options.oauth.dashboardUrl, credentialPort: options.oauth.credentialPort, oauthHttp: new FetchOAuthHttpClient() })
     : null
 
   const container = {

--- a/src/presentation/routes/oauth.ts
+++ b/src/presentation/routes/oauth.ts
@@ -5,7 +5,7 @@ import type { OAuthCredentialPort } from '../../application/oauth/OAuthCredentia
 import { ExchangeOAuthCodeUseCase } from '../../application/oauth/ExchangeOAuthCodeUseCase.js'
 import { RefreshOAuthTokenUseCase } from '../../application/oauth/RefreshOAuthTokenUseCase.js'
 import { DisconnectOAuthUseCase } from '../../application/oauth/DisconnectOAuthUseCase.js'
-import { FetchOAuthHttpClient } from '../../infrastructure/oauth/FetchOAuthHttpClient.js'
+import type { OAuthHttpClient } from '../../application/ports/OAuthHttpClient.js'
 import { OAUTH_RESPONSE_TYPE, OAUTH_PROMPT, ERROR_PLUGIN_NOT_FOUND, ERROR_NO_ORG, ERROR_NO_CREDENTIALS } from '../../defaults.js'
 import pino from 'pino'
 
@@ -16,12 +16,12 @@ interface OAuthRouteDeps {
   requireAuth: (c: unknown, next: () => Promise<void>) => Promise<Response | void>
   dashboardUrl: string
   credentialPort: OAuthCredentialPort
+  oauthHttp: OAuthHttpClient
 }
 
 export function createOAuthRoutes(deps: OAuthRouteDeps) {
   const oauth = new Hono()
-  const { orgRepo, credentialPort, dashboardUrl } = deps
-  const oauthHttp = new FetchOAuthHttpClient()
+  const { orgRepo, credentialPort, dashboardUrl, oauthHttp } = deps
   const exchangeUseCase = new ExchangeOAuthCodeUseCase(orgRepo, credentialPort, oauthHttp, dashboardUrl)
   const refreshUseCase = new RefreshOAuthTokenUseCase(orgRepo, credentialPort, oauthHttp)
   const disconnectUseCase = new DisconnectOAuthUseCase(orgRepo)


### PR DESCRIPTION
## Summary

Final pass of entire core codebase. Resolves all remaining violations:

- OAuth use cases throw `NotFoundError`/`ConfigurationError` instead of `new Error(code)`
- `FetchOAuthHttpClient` instantiation moved from presentation to container.ts (DIP)
- `StatsGenerator` injected into `LifecycleUseCase` constructor (no more inline `new`)
- Unsafe `JSON.parse` in container.ts replaced with typed `safeJsonParse`

After this PR, full codebase passes DDD, SOLID, and Clean Code analysis with zero violations.

## Test plan

- [x] 438 tests pass across 68 files
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)