### PR TITLE
chore: add CI guard against link-poisoned lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,19 @@ permissions:
   pull-requests: write
 
 jobs:
+  lockfile-guard:
+    name: Lockfile hygiene
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Reject local link paths in pnpm-lock.yaml
+        run: |
+          if grep -nE 'link:(/Users/|/home/|/root/|/private/)' pnpm-lock.yaml; then
+            echo "::error file=pnpm-lock.yaml::pnpm-lock.yaml contains absolute local link: paths from .pnpmfile.cjs. Regenerate with the pnpmfile disabled: mv .pnpmfile.cjs .pnpmfile.cjs.bak && pnpm install --lockfile-only && mv .pnpmfile.cjs.bak .pnpmfile.cjs"
+            exit 1
+          fi
+          echo "pnpm-lock.yaml is clean (no local link: paths)."
+
   typecheck:
     name: TypeScript
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a fast `Lockfile hygiene` CI job that fails if `pnpm-lock.yaml` contains absolute local `link:` paths (`/Users/`, `/home/`, `/root/`, `/private/`). This is the `.pnpmfile.cjs` poisoning that broke `pnpm install --frozen-lockfile` in CI and Docker in #181 and went unnoticed for ~2 weeks (fixed in #188).

The job is checkout + grep only, so it runs in seconds and gives a fix hint on failure:

```
mv .pnpmfile.cjs .pnpmfile.cjs.bak && pnpm install --lockfile-only && mv .pnpmfile.cjs.bak .pnpmfile.cjs
```

## Note
The same `.pnpmfile.cjs` local-linking pattern exists in supaproxy-dashboard; worth replicating this guard there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)