### PR TITLE
fix: export knowledge pipeline (indexKnowledge, vectorStore) from container

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -342,6 +342,8 @@ export function createContainer(infra: DatabaseAdapter, options: ContainerOption
     createWorkspaceUseCase, updateWorkspaceUseCase, getWorkspaceDetailUseCase, listWorkspacesUseCase, getWorkspaceSummaryUseCase,
     getDashboardUseCase, getActivityUseCase, deleteConnectionUseCase, getConnectionsUseCase, getKnowledgeUseCase, getComplianceUseCase,
     createKnowledgeSourceUseCase, deleteKnowledgeSourceUseCase, listWorkspaceConsumersUseCase,
+    // Knowledge pipeline (exposed for cloud overlay sync and reindex)
+    indexKnowledge, retrieveKnowledge, vectorStore,
     listWorkspaceGuardrailsUseCase, enableGuardrailUseCase, disableGuardrailUseCase, updateGuardrailEventStatusUseCase,
     getModelsUseCase, getHealthUseCase,
     listConversationsUseCase, getConversationDetailUseCase, closeConversationUseCase,


### PR DESCRIPTION
## Summary

The composition root builds `indexKnowledge`, `retrieveKnowledge`, and `vectorStore` (container.ts:157-160) but never added them to the returned `container` object. The cloud overlay reads `container.indexKnowledge.execute(...)` and `container.vectorStore.deleteBySource(...)` in its knowledge sync to reindex path, so both were `undefined` at runtime.

This was the intended design (the closed #165 described it as "container exports vectorStore and indexKnowledge for cloud overlay") that never landed.

## Change
- Add `indexKnowledge, retrieveKnowledge, vectorStore` to the container return object.

## Verification
- `tsc --noEmit`: clean
- `vitest run`: 439/439
- Cloud type-check: the `container.indexKnowledge` / `container.vectorStore` usages now resolve (they dropped out of cloud's tsc error set).

container.ts is the composition root (coverage-excluded, no unit test per project convention); verified via type-checking and the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)