### PR TITLE
fix: send OAuth redirect_uri to the API callback, not the dashboard

### DIFF
--- a/src/application/oauth/BuildOAuthAuthorizeUrlUseCase.test.ts
+++ b/src/application/oauth/BuildOAuthAuthorizeUrlUseCase.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mockOrgRepo } from '../../__tests__/mocks.js'
+import { BuildOAuthAuthorizeUrlUseCase } from './BuildOAuthAuthorizeUrlUseCase.js'
+import type { OAuthCredentialPort } from './OAuthCredentialService.js'
+
+function mockCredentialPort(): OAuthCredentialPort {
+  return {
+    resolveCredentials: vi.fn().mockResolvedValue({ clientId: 'cid-1', clientSecret: 'csec-1' }),
+    resolveOAuthConfig: vi.fn().mockResolvedValue({
+      authorizeUrl: 'https://auth.example.com/authorize',
+      tokenUrl: 'https://auth.example.com/token',
+      scopes: ['read', 'write'],
+      authorizeParams: { audience: 'api.example.com' },
+    }),
+  }
+}
+
+describe('BuildOAuthAuthorizeUrlUseCase', () => {
+  let orgRepo: ReturnType<typeof mockOrgRepo>
+  let credentialPort: OAuthCredentialPort
+  let useCase: BuildOAuthAuthorizeUrlUseCase
+  const redirectUri = 'https://api.example.com/api/oauth/callback'
+
+  beforeEach(() => {
+    orgRepo = mockOrgRepo()
+    credentialPort = mockCredentialPort()
+    useCase = new BuildOAuthAuthorizeUrlUseCase(orgRepo, credentialPort)
+    vi.mocked(orgRepo.getFirstOrgId).mockResolvedValue('org-1')
+  })
+
+  it('builds an authorize URL with the provided redirect_uri', async () => {
+    const url = await useCase.execute('test-plugin', redirectUri)
+    const parsed = new URL(url)
+
+    expect(parsed.origin + parsed.pathname).toBe('https://auth.example.com/authorize')
+    expect(parsed.searchParams.get('redirect_uri')).toBe(redirectUri)
+    expect(parsed.searchParams.get('client_id')).toBe('cid-1')
+    expect(parsed.searchParams.get('scope')).toBe('read write')
+    expect(parsed.searchParams.get('state')).toContain('test-plugin:')
+    expect(parsed.searchParams.get('audience')).toBe('api.example.com')
+  })
+
+  it('throws when the OAuth config is not found', async () => {
+    vi.mocked(credentialPort.resolveOAuthConfig).mockResolvedValue(null)
+    await expect(useCase.execute('test-plugin', redirectUri)).rejects.toThrow('not found')
+  })
+
+  it('throws when no org exists', async () => {
+    vi.mocked(orgRepo.getFirstOrgId).mockResolvedValue(null)
+    await expect(useCase.execute('test-plugin', redirectUri)).rejects.toThrow('No organisation configured')
+  })
+
+  it('throws when credentials are missing', async () => {
+    vi.mocked(credentialPort.resolveCredentials).mockResolvedValue(null)
+    await expect(useCase.execute('test-plugin', redirectUri)).rejects.toThrow('OAuth credentials not configured')
+  })
+})

--- a/src/application/oauth/BuildOAuthAuthorizeUrlUseCase.ts
+++ b/src/application/oauth/BuildOAuthAuthorizeUrlUseCase.ts
@@ -8,10 +8,9 @@ export class BuildOAuthAuthorizeUrlUseCase {
   constructor(
     private readonly orgRepo: OrganisationRepository,
     private readonly credentialPort: OAuthCredentialPort,
-    private readonly dashboardUrl: string,
   ) {}
 
-  async execute(pluginId: string): Promise<string> {
+  async execute(pluginId: string, redirectUri: string): Promise<string> {
     const config = await this.credentialPort.resolveOAuthConfig(pluginId)
     if (!config) throw new NotFoundError('OAuthConfig', pluginId)
 
@@ -25,7 +24,7 @@ export class BuildOAuthAuthorizeUrlUseCase {
     const params = new URLSearchParams({
       client_id: credentials.clientId,
       scope: config.scopes.join(' '),
-      redirect_uri: `${this.dashboardUrl}/oauth/callback`,
+      redirect_uri: redirectUri,
       state,
       response_type: OAUTH_RESPONSE_TYPE,
       prompt: OAUTH_PROMPT,

--- a/src/application/oauth/ExchangeOAuthCodeUseCase.test.ts
+++ b/src/application/oauth/ExchangeOAuthCodeUseCase.test.ts
@@ -29,6 +29,7 @@ describe('ExchangeOAuthCodeUseCase', () => {
   let oauthHttp: OAuthHttpClient
   let useCase: ExchangeOAuthCodeUseCase
   const dashboardUrl = 'https://dashboard.example.com'
+  const redirectUri = 'https://api.example.com/api/oauth/callback'
 
   beforeEach(() => {
     orgRepo = mockOrgRepo()
@@ -39,13 +40,14 @@ describe('ExchangeOAuthCodeUseCase', () => {
   })
 
   it('exchanges code for tokens and stores them', async () => {
-    const result = await useCase.execute('auth-code-123', 'test-plugin:nonce-1')
+    const result = await useCase.execute('auth-code-123', 'test-plugin:nonce-1', redirectUri)
 
     expect(result.pluginId).toBe('test-plugin')
     expect(result.redirectUrl).toContain('oauth=success')
     expect(oauthHttp.exchangeToken).toHaveBeenCalledWith(expect.objectContaining({
       grantType: 'authorization_code',
       code: 'auth-code-123',
+      redirectUri,
     }))
     expect(orgRepo.upsertSetting).toHaveBeenCalledWith(expect.any(String), 'org-1', 'test-plugin_access_token', 'at-1', true)
     expect(orgRepo.upsertSetting).toHaveBeenCalledWith(expect.any(String), 'org-1', 'test-plugin_refresh_token', 'rt-1', true)
@@ -54,21 +56,21 @@ describe('ExchangeOAuthCodeUseCase', () => {
 
   it('throws when plugin not found', async () => {
     vi.mocked(credentialPort.resolveOAuthConfig).mockResolvedValue(null)
-    await expect(useCase.execute('code', 'test-plugin:nonce')).rejects.toThrow('not found')
+    await expect(useCase.execute('code', 'test-plugin:nonce', redirectUri)).rejects.toThrow('not found')
   })
 
   it('throws when no org exists', async () => {
     vi.mocked(orgRepo.getFirstOrgId).mockResolvedValue(null)
-    await expect(useCase.execute('code', 'test-plugin:nonce')).rejects.toThrow('No organisation configured')
+    await expect(useCase.execute('code', 'test-plugin:nonce', redirectUri)).rejects.toThrow('No organisation configured')
   })
 
   it('throws when credentials are missing', async () => {
     vi.mocked(credentialPort.resolveCredentials).mockResolvedValue(null)
-    await expect(useCase.execute('code', 'test-plugin:nonce')).rejects.toThrow('No OAuth credentials configured')
+    await expect(useCase.execute('code', 'test-plugin:nonce', redirectUri)).rejects.toThrow('No OAuth credentials configured')
   })
 
   it('throws when token exchange fails', async () => {
     vi.mocked(oauthHttp.exchangeToken).mockRejectedValue(new Error('Token exchange failed: 400'))
-    await expect(useCase.execute('bad-code', 'test-plugin:nonce')).rejects.toThrow('Token exchange failed')
+    await expect(useCase.execute('bad-code', 'test-plugin:nonce', redirectUri)).rejects.toThrow('Token exchange failed')
   })
 })

--- a/src/application/oauth/ExchangeOAuthCodeUseCase.ts
+++ b/src/application/oauth/ExchangeOAuthCodeUseCase.ts
@@ -20,7 +20,7 @@ export class ExchangeOAuthCodeUseCase {
     private readonly dashboardUrl: string,
   ) {}
 
-  async execute(code: string, state: string): Promise<ExchangeResult> {
+  async execute(code: string, state: string, redirectUri: string): Promise<ExchangeResult> {
     const pluginId = state.split(':')[0] || null
     if (!pluginId) throw new NotFoundError('Plugin', state)
 
@@ -39,7 +39,7 @@ export class ExchangeOAuthCodeUseCase {
       clientSecret: credentials.clientSecret,
       grantType: 'authorization_code',
       code,
-      redirectUri: `${this.dashboardUrl}/oauth/callback`,
+      redirectUri,
     })
 
     await this.storeTokens(orgId, pluginId, tokens)

--- a/src/container.ts
+++ b/src/container.ts
@@ -322,7 +322,7 @@ export function createContainer(infra: DatabaseAdapter, options: ContainerOption
   let oauthRoutes = null
   if (options.oauth) {
     const oauthHttp = new FetchOAuthHttpClient()
-    const buildOAuthAuthorizeUrlUseCase = new BuildOAuthAuthorizeUrlUseCase(orgRepo, options.oauth.credentialPort, options.oauth.dashboardUrl)
+    const buildOAuthAuthorizeUrlUseCase = new BuildOAuthAuthorizeUrlUseCase(orgRepo, options.oauth.credentialPort)
     const exchangeOAuthCodeUseCase = new ExchangeOAuthCodeUseCase(orgRepo, options.oauth.credentialPort, oauthHttp, options.oauth.dashboardUrl)
     const refreshOAuthTokenUseCase = new RefreshOAuthTokenUseCase(orgRepo, options.oauth.credentialPort, oauthHttp)
     const disconnectOAuthUseCase = new DisconnectOAuthUseCase(orgRepo)

--- a/src/presentation/controllers/oauth.ts
+++ b/src/presentation/controllers/oauth.ts
@@ -8,6 +8,18 @@ import pino from 'pino'
 
 const log = pino({ name: 'oauth' })
 
+/**
+ * The OAuth callback must hit the API server (where the code exchange runs),
+ * not the dashboard. Derive it from the incoming request so it matches the
+ * value registered in the provider's app and works across environments.
+ */
+function callbackUrl(c: import('hono').Context): string {
+  const url = new URL(c.req.url)
+  const proto = c.req.header('x-forwarded-proto') || url.protocol.replace(':', '')
+  const host = c.req.header('x-forwarded-host') || url.host
+  return `${proto}://${host}/api/oauth/callback`
+}
+
 export interface OAuthRouteDeps {
   buildOAuthAuthorizeUrlUseCase: BuildOAuthAuthorizeUrlUseCase
   exchangeOAuthCodeUseCase: ExchangeOAuthCodeUseCase
@@ -21,7 +33,7 @@ export interface OAuthRouteDeps {
 export function authorize(deps: OAuthRouteDeps) {
   return async (c: import('hono').Context) => {
     try {
-      const url = await deps.buildOAuthAuthorizeUrlUseCase.execute(c.req.param('pluginId')!)
+      const url = await deps.buildOAuthAuthorizeUrlUseCase.execute(c.req.param('pluginId')!, callbackUrl(c))
       return c.redirect(url)
     } catch (err) {
       if (err instanceof NotFoundError) return c.json({ error: 'plugin_not_found' }, 404)
@@ -46,7 +58,7 @@ export function callback(deps: OAuthRouteDeps) {
     }
 
     try {
-      const result = await deps.exchangeOAuthCodeUseCase.execute(code, state)
+      const result = await deps.exchangeOAuthCodeUseCase.execute(code, state, callbackUrl(c))
       return c.redirect(result.redirectUrl)
     } catch (err) {
       const pluginId = state.split(':')[0]


### PR DESCRIPTION
## Summary

Reconnecting a Confluence (OAuth) source failed with Atlassian's "the app's callback URL is invalid". The authorize and token-exchange flows built `redirect_uri` as `{dashboardUrl}/oauth/callback` (e.g. `http://localhost:4323/oauth/callback`), but the callback handler is on the API server at `/api/oauth/callback`. So the URL sent to Atlassian was both unregistrable and pointed at the wrong server.

## Change
- Derive the callback URL from the incoming request (`Host`, honouring `x-forwarded-proto`/`x-forwarded-host`) in the OAuth controller.
- Pass it into `BuildOAuthAuthorizeUrlUseCase.execute(pluginId, redirectUri)` and `ExchangeOAuthCodeUseCase.execute(code, state, redirectUri)`, so authorize and exchange always use an identical `redirect_uri` that targets the API's real callback.
- Drop the now-unused `dashboardUrl` from `BuildOAuthAuthorizeUrlUseCase` (still used for the post-OAuth browser redirect).

## Required app config
The OAuth provider app must list the API callback as an allowed URL, e.g. `http://localhost:3002/api/oauth/callback` for local dev and the API domain in production.

## Tests
443 pass (adds `BuildOAuthAuthorizeUrlUseCase` test; updates `ExchangeOAuthCodeUseCase`). `tsc --noEmit` clean.

## Follow-ups (from the closed #161, not in this PR)
- OAuth uses `getFirstOrgId()`; should use the authenticated user's `org_id` (and encode it in `state` for the callback) for multi-tenant correctness.
- Post-OAuth redirect goes to `/settings`; could target `/knowledge-base/sources` or `/marketplace/{pluginId}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)