### PR TITLE
fix: resolve 'auto' model and answer immediately after routing

### DIFF
--- a/src/application/query/ExecuteQueryUseCase.ts
+++ b/src/application/query/ExecuteQueryUseCase.ts
@@ -16,6 +16,7 @@ import type { ToolCallProcessor } from './ToolCallProcessor.js'
 import type { ToolEntry } from './ToolCallProcessor.js'
 import { runAgentLoop, buildEmptyResult, buildQueryResult, buildAuditLogData, recordMessages, type QueryMeta, type QueryResult, type AgentLoopResult } from './AgentLoopHelpers.js'
 import { resolveProvider } from './ProviderResolver.js'
+import { resolveModel } from './ModelResolver.js'
 import { discoverTools } from './ToolDiscovery.js'
 import { screenInput } from './InputScreener.js'
 import { buildSystemPrompt } from './SystemPromptBuilder.js'
@@ -100,7 +101,8 @@ export class ExecuteQueryUseCase {
 
     try {
       if (tools.length === 0) log.info({ workspace: workspaceId }, 'No tools discovered, running as direct LLM conversation')
-      if (!workspace.model) throw new ConfigurationError(ERROR_CODES.NO_WORKSPACE_MODEL)
+      const model = resolveModel(provider, workspace.model)
+      if (!model) throw new ConfigurationError(ERROR_CODES.NO_WORKSPACE_MODEL)
 
       const systemPrompt = await buildSystemPrompt(
         { workspace, systemPromptOverride: meta.systemPromptOverride, workspaceId, queryToForward },
@@ -109,7 +111,7 @@ export class ExecuteQueryUseCase {
       )
 
       const result = await runAgentLoop(queryToForward, provider, {
-        model: workspace.model,
+        model,
         systemPrompt: systemPrompt.text,
         maxToolRounds: workspace.max_tool_rounds || DEFAULT_MAX_TOOL_ROUNDS,
         tools, history, apiKey, workspaceId, conversationId, executionRails, retrievalRails,

--- a/src/application/query/ModelResolver.test.ts
+++ b/src/application/query/ModelResolver.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { resolveModel, AUTO_MODEL } from './ModelResolver.js'
+import type { ProviderPlugin } from '@supaproxy/providers'
+
+function providerWith(models: Array<{ id: string; label: string; default?: boolean }>): ProviderPlugin {
+  return { models } as ProviderPlugin
+}
+
+describe('resolveModel', () => {
+  const provider = providerWith([
+    { id: 'model-a', label: 'A' },
+    { id: 'model-b', label: 'B', default: true },
+  ])
+
+  it('returns an explicit model unchanged', () => {
+    expect(resolveModel(provider, 'model-a')).toBe('model-a')
+  })
+
+  it("resolves 'auto' to the provider default model", () => {
+    expect(resolveModel(provider, AUTO_MODEL)).toBe('model-b')
+  })
+
+  it('resolves empty or null to the provider default model', () => {
+    expect(resolveModel(provider, null)).toBe('model-b')
+    expect(resolveModel(provider, '')).toBe('model-b')
+  })
+
+  it('falls back to the first model when none is flagged default', () => {
+    const p = providerWith([{ id: 'only', label: 'Only' }])
+    expect(resolveModel(p, AUTO_MODEL)).toBe('only')
+  })
+
+  it('returns null when the provider declares no models', () => {
+    expect(resolveModel(providerWith([]), AUTO_MODEL)).toBeNull()
+  })
+})

--- a/src/application/query/ModelResolver.ts
+++ b/src/application/query/ModelResolver.ts
@@ -1,0 +1,17 @@
+import type { ProviderPlugin } from '@supaproxy/providers'
+
+/** Sentinel meaning "let the platform choose the provider's default model". */
+export const AUTO_MODEL = 'auto'
+
+/**
+ * Resolve a workspace's configured model to a concrete model id.
+ *
+ * An explicit model is used as-is. 'auto' (or an empty value) resolves to the
+ * provider's declared default model, falling back to its first declared model.
+ * Returns null only when the provider declares no models.
+ */
+export function resolveModel(provider: ProviderPlugin, workspaceModel: string | null): string | null {
+  if (workspaceModel && workspaceModel !== AUTO_MODEL) return workspaceModel
+  const fallback = provider.models.find(m => m.default) ?? provider.models[0]
+  return fallback?.id ?? null
+}

--- a/src/application/routing/RouteMessageUseCase.test.ts
+++ b/src/application/routing/RouteMessageUseCase.test.ts
@@ -79,7 +79,7 @@ describe('RouteMessageUseCase', () => {
     expect(sessionStore.set).toHaveBeenCalled()
   })
 
-  it('routes via receptionist when no session exists and LLM returns routing directive', async () => {
+  it('routes via receptionist and the target workspace answers immediately', async () => {
     const defaultWs = stubWorkspace({ id: 'ws-general', name: '#general', is_default: true })
     const targetWs = stubWorkspace({ id: 'ws-insurance', name: 'Insurance' })
 
@@ -90,26 +90,41 @@ describe('RouteMessageUseCase', () => {
     ])
     vi.mocked(workspaceRepo.findActiveById).mockResolvedValue(targetWs)
 
-    // Receptionist decides to route
-    vi.mocked(executeQuery.execute).mockResolvedValue({
-      answer: "I'll connect you with our insurance team.\n<!-- ROUTE:ws-insurance:User asked about car accident -->",
-      conversationId: 'conv-1',
-      sessionId: 'session-1',
-      toolsCalled: [],
-      connectionsHit: [],
-      tokensInput: 10,
-      tokensOutput: 20,
-      costUsd: 0.001,
-      durationMs: 100,
-      error: null,
-    })
+    // No existing session, then the session the router just created on route.
+    vi.mocked(sessionStore.get)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue({
+        workspaceId: 'ws-insurance',
+        lastMessageAt: Date.now(),
+        routedFrom: '#general',
+        routedFromConversationId: 'conv-general',
+        generalConversationId: 'conv-general',
+      })
+
+    // First execute: receptionist routes. Second execute: target workspace answers.
+    vi.mocked(executeQuery.execute)
+      .mockResolvedValueOnce({
+        answer: "I'll connect you with our insurance team.\n<!-- ROUTE:ws-insurance:User asked about car accident -->",
+        conversationId: 'conv-general', sessionId: 'session-1', toolsCalled: [], connectionsHit: [],
+        tokensInput: 10, tokensOutput: 20, costUsd: 0.001, durationMs: 100, error: null,
+      })
+      .mockResolvedValueOnce({
+        answer: 'To file an accident claim, you can do it online or call our claims line.',
+        conversationId: 'conv-insurance', sessionId: 'session-1', toolsCalled: [], connectionsHit: [],
+        tokensInput: 10, tokensOutput: 20, costUsd: 0.001, durationMs: 100, error: null,
+      })
 
     const result = await useCase.execute(baseInput)
 
     expect(result.routed).toBe(true)
     expect(result.routedTo).toBe('Insurance')
-    expect(result.answer).toContain('[Connected to Insurance]')
+    // The routed workspace answers immediately, not a "connecting you" filler.
+    expect(result.answer).toBe('To file an accident claim, you can do it online or call our claims line.')
     expect(result.answer).not.toContain('<!-- ROUTE')
+    // The original query is executed in the target workspace, carrying reception scope.
+    expect(executeQuery.execute).toHaveBeenLastCalledWith('ws-insurance', baseInput.query, expect.objectContaining({
+      routedFrom: '#general',
+    }))
     expect(sessionStore.set).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({ workspaceId: 'ws-insurance' }),

--- a/src/application/routing/RouteMessageUseCase.ts
+++ b/src/application/routing/RouteMessageUseCase.ts
@@ -52,7 +52,49 @@ export class RouteMessageUseCase {
       return this.handleExistingSession(input, sessionKey, existingSession)
     }
 
-    return this.router.route(input, sessionKey)
+    const routed = await this.router.route(input, sessionKey)
+    if (!routed.routed) {
+      return { answer: routed.answer, conversationId: routed.conversationId, workspaceId: routed.workspaceId, routed: false }
+    }
+
+    // Routed: answer the query immediately in the target workspace, carrying
+    // the receptionist (#general) history so it has the scope from reception.
+    const session = await this.sessionStore.get(sessionKey)
+    const result = await this.executeInWorkspace(routed.workspaceId, input, sessionKey, session)
+    return {
+      answer: result.answer,
+      conversationId: result.conversationId,
+      workspaceId: routed.workspaceId,
+      routed: true,
+      routedTo: routed.routedTo,
+    }
+  }
+
+  // Execute the query in a workspace, carrying any routed-from history, and
+  // mirror the exchange to the #general master conversation.
+  private async executeInWorkspace(
+    workspaceId: string,
+    input: RouteMessageInput,
+    sessionKey: string,
+    session: RoutingSession | null,
+  ): Promise<{ answer: string; conversationId: string }> {
+    const priorHistory = session?.routedFromConversationId
+      ? await this.conversationUseCase.getHistory(session.routedFromConversationId)
+      : undefined
+    const result = await this.executeQueryUseCase.execute(workspaceId, input.query, {
+      consumerType: input.consumerType,
+      channel: input.entryPoint,
+      userId: input.userId,
+      userName: input.userName,
+      sessionId: sessionKey,
+      routedFrom: session?.routedFrom || undefined,
+      routedFromConversationId: session?.routedFromConversationId || undefined,
+      priorHistory,
+    })
+    if (session?.generalConversationId) {
+      await this.router.logToGeneral(session.generalConversationId, input.query, result.answer)
+    }
+    return { answer: result.answer, conversationId: result.conversationId }
   }
 
   private async handleExistingSession(
@@ -75,24 +117,7 @@ export class RouteMessageUseCase {
       }
     }
 
-    const priorHistory = existingSession.routedFromConversationId
-      ? await this.conversationUseCase.getHistory(existingSession.routedFromConversationId)
-      : undefined
-
-    const result = await this.executeQueryUseCase.execute(existingSession.workspaceId, input.query, {
-      consumerType: input.consumerType,
-      channel: input.entryPoint,
-      userId: input.userId,
-      userName: input.userName,
-      sessionId: sessionKey,
-      routedFrom: existingSession.routedFrom || undefined,
-      routedFromConversationId: existingSession.routedFromConversationId || undefined,
-      priorHistory,
-    })
-
-    if (existingSession.generalConversationId) {
-      await this.router.logToGeneral(existingSession.generalConversationId, input.query, result.answer)
-    }
+    const result = await this.executeInWorkspace(existingSession.workspaceId, input, sessionKey, existingSession)
 
     const outOfScope = existingSession.routedFrom && isRedirectOffer(result.answer)
     const redirectOffered = isRedirectOffer(result.answer)


### PR DESCRIPTION
## Summary

Two fixes for the receptionist routing test flow (reported via the dashboard "Test routing" playground).

### 1. `model: auto` 404
Workspaces are created with `model: 'auto'` (the create-workspace default), which was passed **literally** to the provider, returning `404 not_found_error: model: auto`. Every receptionist and routed-workspace query failed.

- New `resolveModel(provider, workspaceModel)` maps `'auto'` (or empty) to the provider's **declared default model** (`provider.models.find(m => m.default)`), falling back to its first model. Provider-agnostic, no hardcoded model ids.
- Wired into `ExecuteQueryUseCase` (covers receptionist, redirect-intent, routed, and direct paths).

### 2. Routed workspace now answers immediately
After the receptionist routed, it returned a "connecting you" message and the user had to **reprompt** to get an answer. Now `RouteMessageUseCase` executes the original query in the target workspace in the same turn, carrying the `#general` history as the scope from reception. The shared "execute in workspace + log to #general" logic is extracted to a helper (also keeps the file within the size limit).

## Verification
- `tsc --noEmit` clean; **448 tests pass** (adds `ModelResolver` tests; updates the routing test to the two-call flow).
- Runtime: cleared the session and routed "How do I apply for a loan?" → routed to **Lending**, which answered immediately from its synced governance (verify identity → KYC → OTP → affordability). No reprompt, no model error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)