### PR TITLE
fix: redirect re-routes also answer immediately

### DIFF
--- a/src/application/routing/RouteMessageUseCase.test.ts
+++ b/src/application/routing/RouteMessageUseCase.test.ts
@@ -245,12 +245,29 @@ describe('RouteMessageUseCase', () => {
         durationMs: 100,
         error: null,
       })
+      // Third call: the routed Insurance workspace answers immediately
+      .mockResolvedValueOnce({
+        answer: 'What would you like to know about your insurance policy?',
+        conversationId: 'conv-insurance',
+        sessionId: 'session-3',
+        toolsCalled: [],
+        connectionsHit: [],
+        tokensInput: 10,
+        tokensOutput: 20,
+        costUsd: 0.001,
+        durationMs: 100,
+        error: null,
+      })
 
     const result = await useCase.execute({ ...baseInput, query: 'Yes please' })
 
     // Session should have been deleted before re-routing
     expect(sessionStore.delete).toHaveBeenCalled()
     expect(result.routed).toBe(true)
+    expect(result.routedTo).toBe('Insurance')
+    // The redirect answers immediately in the target, not a "connecting you" message
+    expect(result.answer).toBe('What would you like to know about your insurance policy?')
+    expect(executeQuery.execute).toHaveBeenLastCalledWith('ws-insurance', 'Yes please', expect.anything())
   })
 
   it('continues in current workspace when pendingRedirect is true but user declines', async () => {

--- a/src/application/routing/RouteMessageUseCase.ts
+++ b/src/application/routing/RouteMessageUseCase.ts
@@ -52,13 +52,17 @@ export class RouteMessageUseCase {
       return this.handleExistingSession(input, sessionKey, existingSession)
     }
 
+    return this.routeAndAnswer(input, sessionKey)
+  }
+
+  // Run the receptionist and, when it routes, answer the query immediately in
+  // the target workspace (carrying the #general history as scope from
+  // reception) rather than returning a "connecting you" message.
+  private async routeAndAnswer(input: RouteMessageInput, sessionKey: string): Promise<RouteMessageOutput> {
     const routed = await this.router.route(input, sessionKey)
     if (!routed.routed) {
       return { answer: routed.answer, conversationId: routed.conversationId, workspaceId: routed.workspaceId, routed: false }
     }
-
-    // Routed: answer the query immediately in the target workspace, carrying
-    // the receptionist (#general) history so it has the scope from reception.
     const session = await this.sessionStore.get(sessionKey)
     const result = await this.executeInWorkspace(routed.workspaceId, input, sessionKey, session)
     return {
@@ -104,7 +108,7 @@ export class RouteMessageUseCase {
   ): Promise<RouteMessageOutput> {
     const defaultWs = await this.workspaceRepo.findDefaultByOrg(input.orgId)
     if (defaultWs && existingSession.workspaceId === defaultWs.id && !existingSession.routedFrom) {
-      return this.router.route(input, sessionKey)
+      return this.routeAndAnswer(input, sessionKey)
     }
 
     if (existingSession.pendingRedirect) {
@@ -113,7 +117,7 @@ export class RouteMessageUseCase {
       log.info({ sessionKey, wantsRedirect }, 'Redirect intent result')
       if (wantsRedirect) {
         await this.sessionStore.delete(sessionKey)
-        return this.router.route(input, sessionKey)
+        return this.routeAndAnswer(input, sessionKey)
       }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #194. That fix made the no-session route path answer in the target workspace, but the **re-route paths** inside `handleExistingSession` still returned the receptionist's "connecting you" message:
- the pending-redirect flow ("you're outside scope of X, redirect? → Yes"), and
- the `#general` re-route.

So a redirected user got no real answer until they prompted again.

This consolidates every route entry point through a single `routeAndAnswer()` method, so all of them answer the query immediately in the target workspace (carrying the `#general` history as scope).

## Verification
- 448 tests pass; the redirect test now asserts the target answers immediately (not a connecting message).
- Runtime: in Lending, "I need to know about your insurance policies" → "outside scope of Lending, redirect?" → "Yes" now routes to Insurance **and answers in the same turn**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)